### PR TITLE
ACCUMULO-1641 Removed use of non public Accumulo command line parsing…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /target/
 /*.iml
 /.idea
+/examples.conf

--- a/README.md
+++ b/README.md
@@ -34,15 +34,20 @@ Before running any of the examples, the following steps must be performed.
         git clone https://github.com/apache/accumulo-examples.git
         mvn clean package
 
-4. Each Accumulo example has its own documentation and instructions for running the example which
+4. Specify connection information.  All examples read connection information from a properties 
+   file. Copy the template and edit it.
+
+        cd accumulo-examples
+        cp examples.conf.template examples.conf
+        nano examples.conf
+
+5. Each Accumulo example has its own documentation and instructions for running the example which
    are linked to below.
 
 When running the examples, remember the tips below:
 
 * Examples are run using the `runex` command which is located in the `bin/` directory of this repo.
   The `runex` command is a simple wrapper around the Maven Exec plugin.
-* Any command that references Accumulo settings such as `instance`, `zookeepers`, `username`, or 
-`password` should be updated for your instance.
 * Commands intended to be run in bash are prefixed by '$' and should be run from the root of this
   repository.
 * Several examples use the `accumulo` and `tool.sh` commands which are expected to be on your 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Before running any of the examples, the following steps must be performed.
         git clone https://github.com/apache/accumulo-examples.git
         mvn clean package
 
-4. Specify connection information.  All examples read connection information from a properties 
-   file. Copy the template and edit it.
+4. Specify Accumulo connection information.  All examples read connection information from a 
+   properties file. Copy the template and edit it.
 
         cd accumulo-examples
         cp examples.conf.template examples.conf
@@ -86,6 +86,11 @@ Each example below highlights a feature of Apache Accumulo.
 | [tabletofile] | Using MapReduce to read a table and write one of its columns to a file in HDFS. |
 | [terasort] | Generating random data and sorting it using Accumulo. |
 | [visibility] | Using visibilities (or combinations of authorizations). Also shows user permissions. |
+
+## Release Testing
+
+This repository can be used to test Accumulo release candidates.  See
+[docs/release-testing.md](docs/release-testing.md).
 
 [manual]: https://accumulo.apache.org/latest/accumulo_user_manual/
 [INSTALL.md]: https://github.com/apache/accumulo/blob/master/INSTALL.md

--- a/bin/runex
+++ b/bin/runex
@@ -18,4 +18,8 @@
 main_class="$1"
 main_args="${*:2}"
 
-mvn -q exec:java -Dexec.mainClass="org.apache.accumulo.examples.$main_class" -Dexec.args="$main_args"
+if command -v accumulo > /dev/null 2>&1 ; then
+  av_arg="-Daccumulo.version=`accumulo version`"
+fi
+
+mvn -q exec:java -Dexec.mainClass="org.apache.accumulo.examples.$main_class" $av_arg -Dexec.args="$main_args"

--- a/docs/batch.md
+++ b/docs/batch.md
@@ -40,8 +40,8 @@ Before you run this, you must ensure that the user you are running has the
 You must also create the table, batchtest1, ahead of time. (In the shell, use "createtable batchtest1")
 
     $ accumulo shell -u username -e "createtable batchtest1"
-    $ ./bin/runex client.SequentialBatchWriter -i instance -z zookeepers -u username -p password -t batchtest1 --start 0 --num 10000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20 --vis exampleVis
-    $ ./bin/runex client.RandomBatchScanner -i instance -z zookeepers -u username -p password -t batchtest1 --num 100 --min 0 --max 10000 --size 50 --scanThreads 20 --auths exampleVis
+    $ ./bin/runex client.SequentialBatchWriter -c ./examples.conf -t batchtest1 --start 0 --num 10000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20 --vis exampleVis
+    $ ./bin/runex client.RandomBatchScanner -c ./examples.conf -t batchtest1 --num 100 --min 0 --max 10000 --size 50 --scanThreads 20 --auths exampleVis
     07 11:33:11,103 [client.CountingVerifyingReceiver] INFO : Generating 100 random queries...
     07 11:33:11,112 [client.CountingVerifyingReceiver] INFO : finished
     07 11:33:11,260 [client.CountingVerifyingReceiver] INFO : 694.44 lookups/sec   0.14 secs

--- a/docs/bloom.md
+++ b/docs/bloom.md
@@ -39,7 +39,7 @@ Below 1 million random values are inserted into accumulo. The randomly
 generated rows range between 0 and 1 billion. The random number generator is
 initialized with the seed 7.
 
-    $ ./bin/runex client.RandomBatchWriter --seed 7 -i instance -z zookeepers -u username -p password -t bloom_test --num 1000000 --min 0 --max 1000000000 --size 50 --batchMemory 2M --batchLatency 60s --batchThreads 3 --vis exampleVis
+    $ ./bin/runex client.RandomBatchWriter --seed 7 -c ./examples.conf -t bloom_test --num 1000000 --min 0 --max 1000000000 --size 50 --batchMemory 2M --batchLatency 60 --batchThreads 3 --vis exampleVis
 
 Below the table is flushed:
 
@@ -50,7 +50,7 @@ After the flush completes, 500 random queries are done against the table. The
 same seed is used to generate the queries, therefore everything is found in the
 table.
 
-    $ ./bin/runex client.RandomBatchScanner --seed 7 -i instance -z zookeepers -u username -p password -t bloom_test --num 500 --min 0 --max 1000000000 --size 50 --scanThreads 20 --auths exampleVis
+    $ ./bin/runex client.RandomBatchScanner --seed 7 -c ./examples.conf -t bloom_test --num 500 --min 0 --max 1000000000 --size 50 --scanThreads 20 --auths exampleVis
     Generating 500 random queries...finished
     96.19 lookups/sec   5.20 secs
     num results : 500
@@ -62,7 +62,7 @@ Below another 500 queries are performed, using a different seed which results
 in nothing being found. In this case the lookups are much faster because of
 the bloom filters.
 
-    $ ./bin/runex client.RandomBatchScanner --seed 8 -i instance -z zookeepers -u username -p password -t bloom_test --num 500 --min 0 --max 1000000000 --size 50 -batchThreads 20 -auths exampleVis
+    $ ./bin/runex client.RandomBatchScanner --seed 8 -c ./examples.conf -t bloom_test --num 500 --min 0 --max 1000000000 --size 50 -batchThreads 20 -auths exampleVis
     Generating 500 random queries...finished
     2212.39 lookups/sec   0.23 secs
     num results : 0
@@ -113,7 +113,7 @@ The commands for creating the first table without bloom filters are below.
     username@instance bloom_test1> config -t bloom_test1 -s table.compaction.major.ratio=7
     username@instance bloom_test1> exit
 
-    $ ARGS="-i instance -z zookeepers -u username -p password -t bloom_test1 --num 1000000 --min 0 --max 1000000000 --size 50 --batchMemory 2M --batchLatency 60s --batchThreads 3 --vis exampleVis"
+    $ ARGS="-c ./examples.conf -t bloom_test1 --num 1000000 --min 0 --max 1000000000 --size 50 --batchMemory 2M --batchLatency 60 --batchThreads 3 --vis exampleVis"
     $ ./bin/runex client.RandomBatchWriter --seed 7 $ARGS
     $ accumulo shell -u username -p password -e 'flush -t bloom_test1 -w'
     $ ./bin/runex client.RandomBatchWriter --seed 8 $ARGS
@@ -137,7 +137,7 @@ The commands for creating the second table with bloom filers are below.
     username@instance bloom_test2> config -t bloom_test2 -s table.bloom.enabled=true
     username@instance bloom_test2> exit
 
-    $ ARGS="-i instance -z zookeepers -u username -p password -t bloom_test2 --num 1000000 --min 0 --max 1000000000 --size 50 --batchMemory 2M --batchLatency 60s --batchThreads 3 --vis exampleVis"
+    $ ARGS="-c ./examples.conf -t bloom_test2 --num 1000000 --min 0 --max 1000000000 --size 50 --batchMemory 2M --batchLatency 60 --batchThreads 3 --vis exampleVis"
     $ ./bin/runex client.RandomBatchWriter --seed 7 $ARGS
     $ accumulo shell -u username -p password -e 'flush -t bloom_test2 -w'
     $ ./bin/runex client.RandomBatchWriter --seed 8 $ARGS
@@ -149,7 +149,7 @@ Below 500 lookups are done against the table without bloom filters using random
 NG seed 7. Even though only one map file will likely contain entries for this
 seed, all map files will be interrogated.
 
-    $ ./bin/runex client.RandomBatchScanner --seed 7 -i instance -z zookeepers -u username -p password -t bloom_test1 --num 500 --min 0 --max 1000000000 --size 50 --scanThreads 20 --auths exampleVis
+    $ ./bin/runex client.RandomBatchScanner --seed 7 -c ./examples.conf -t bloom_test1 --num 500 --min 0 --max 1000000000 --size 50 --scanThreads 20 --auths exampleVis
     Generating 500 random queries...finished
     35.09 lookups/sec  14.25 secs
     num results : 500
@@ -161,7 +161,7 @@ Below the same lookups are done against the table with bloom filters. The
 lookups were 2.86 times faster because only one map file was used, even though three
 map files existed.
 
-    $ ./bin/runex client.RandomBatchScanner --seed 7 -i instance -z zookeepers -u username -p password -t bloom_test2 --num 500 --min 0 --max 1000000000 --size 50 -scanThreads 20 --auths exampleVis
+    $ ./bin/runex client.RandomBatchScanner --seed 7 -c ./examples.conf -t bloom_test2 --num 500 --min 0 --max 1000000000 --size 50 -scanThreads 20 --auths exampleVis
     Generating 500 random queries...finished
     99.03 lookups/sec   5.05 secs
     num results : 500

--- a/docs/client.md
+++ b/docs/client.md
@@ -28,13 +28,12 @@ Using the accumulo command, you can run the simple client examples by providing 
 class name, and enough arguments to find your accumulo instance. For example,
 the Flush class will flush a table:
 
-    $ PACKAGE=org.apache.accumulo.examples.client
-    $ bin/accumulo $PACKAGE.Flush -u root -p mypassword -i instance -z zookeeper -t trace
+    $ ./bin/runex client.Flush -c ./examples.conf -t trace
 
 The very simple RowOperations class demonstrates how to read and write rows using the BatchWriter
 and Scanner:
 
-    $ bin/accumulo $PACKAGE.RowOperations -u root -p mypassword -i instance -z zookeeper
+    $ ./bin/runex client.RowOperations -c ./examples.conf
     2013-01-14 14:45:24,738 [client.RowOperations] INFO : This is everything
     2013-01-14 14:45:24,744 [client.RowOperations] INFO : Key: row1 column:1 [] 1358192724640 false Value: This is the value for this key
     2013-01-14 14:45:24,744 [client.RowOperations] INFO : Key: row1 column:2 [] 1358192724642 false Value: This is the value for this key
@@ -65,7 +64,7 @@ and Scanner:
 
 To create a table, write to it and read from it:
 
-    $ bin/accumulo $PACKAGE.ReadWriteExample -u root -p mypassword -i instance -z zookeeper --createtable --create --read
+    $ ./bin/runex client.ReadWriteExample -c ./examples.conf --createtable --create --read
     hello%00; datatypes:xml [LEVEL1|GROUP1] 1358192329450 false -> world
     hello%01; datatypes:xml [LEVEL1|GROUP1] 1358192329450 false -> world
     hello%02; datatypes:xml [LEVEL1|GROUP1] 1358192329450 false -> world

--- a/docs/compactionStrategy.md
+++ b/docs/compactionStrategy.md
@@ -44,13 +44,13 @@ The commands below will configure the TwoTierCompactionStrategy to use gz compre
 
 Generate some data and files in order to test the strategy:
 
-    $ ./bin/runex client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 10000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
+    $ ./bin/runex client.SequentialBatchWriter -c ./examples.conf -t test1 --start 0 --num 10000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
     $ accumulo shell -u root -p secret -e "flush -t test1"
-    $ ./bin/runex client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 11000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
+    $ ./bin/runex client.SequentialBatchWriter -c ./examples.conf -t test1 --start 0 --num 11000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
     $ accumulo shell -u root -p secret -e "flush -t test1"
-    $ ./bin/runex client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 12000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
+    $ ./bin/runex client.SequentialBatchWriter -c ./examples.conf -t test1 --start 0 --num 12000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
     $ accumulo shell -u root -p secret -e "flush -t test1"
-    $ ./bin/runex client.SequentialBatchWriter -i instance17 -z localhost:2181 -u root -p secret -t test1 --start 0 --num 13000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
+    $ ./bin/runex client.SequentialBatchWriter -c ./examples.conf -t test1 --start 0 --num 13000 --size 50 --batchMemory 20M --batchLatency 500 --batchThreads 20
     $ accumulo shell -u root -p secret -e "flush -t test1"
 
 View the tserver log in <accumulo_home>/logs for the compaction and find the name of the <rfile> that was compacted for your table. Print info about this file using the PrintInfo tool:

--- a/docs/dirlist.md
+++ b/docs/dirlist.md
@@ -31,7 +31,7 @@ This example shows how to use Accumulo to store a file system history. It has th
 
 To begin, ingest some data with Ingest.java.
 
-    $ ./bin/runex dirlist.Ingest -i instance -z zookeepers -u username -p password --vis exampleVis --chunkSize 100000 /local/username/workspace
+    $ ./bin/runex dirlist.Ingest -c ./examples.conf --vis exampleVis --chunkSize 100000 /local/username/workspace
 
 This may take some time if there are large files in the /local/username/workspace directory. If you use 0 instead of 100000 on the command line, the ingest will run much faster, but it will not put any file data into Accumulo (the dataTable will be empty).
 Note that running this example will create tables dirTable, indexTable, and dataTable in Accumulo that you should delete when you have completed the example.
@@ -43,26 +43,26 @@ To browse the data ingested, use Viewer.java. Be sure to give the "username" use
 
 then run the Viewer:
 
-    $ ./bin/runex dirlist.Viewer -i instance -z zookeepers -u username -p password -t dirTable --dataTable dataTable --auths exampleVis --path /local/username/workspace
+    $ ./bin/runex dirlist.Viewer -c ./examples.conf -t dirTable --dataTable dataTable --auths exampleVis --path /local/username/workspace
 
 To list the contents of specific directories, use QueryUtil.java.
 
-    $ ./bin/runex dirlist.QueryUtil -i instance -z zookeepers -u username -p password -t dirTable --auths exampleVis --path /local/username
-    $ ./bin/runex dirlist.QueryUtil -i instance -z zookeepers -u username -p password -t dirTable --auths exampleVis --path /local/username/workspace
+    $ ./bin/runex dirlist.QueryUtil -c ./examples.conf -t dirTable --auths exampleVis --path /local/username
+    $ ./bin/runex dirlist.QueryUtil -c ./examples.conf -t dirTable --auths exampleVis --path /local/username/workspace
 
 To perform searches on file or directory names, also use QueryUtil.java. Search terms must contain no more than one wild card and cannot contain "/".
 *Note* these queries run on the _indexTable_ table instead of the dirTable table.
 
-    $ ./bin/runex dirlist.QueryUtil -i instance -z zookeepers -u username -p password -t indexTable --auths exampleVis --path filename --search
-    $ ./bin/runex dirlist.QueryUtil -i instance -z zookeepers -u username -p password -t indexTable --auths exampleVis --path 'filename*' --search
-    $ ./bin/runex dirlist.QueryUtil -i instance -z zookeepers -u username -p password -t indexTable --auths exampleVis --path '*jar' --search
-    $ ./bin/runex dirlist.QueryUtil -i instance -z zookeepers -u username -p password -t indexTable --auths exampleVis --path 'filename*jar' --search
+    $ ./bin/runex dirlist.QueryUtil -c ./examples.conf -t indexTable --auths exampleVis --path filename --search
+    $ ./bin/runex dirlist.QueryUtil -c ./examples.conf -t indexTable --auths exampleVis --path 'filename*' --search
+    $ ./bin/runex dirlist.QueryUtil -c ./examples.conf -t indexTable --auths exampleVis --path '*jar' --search
+    $ ./bin/runex dirlist.QueryUtil -c ./examples.conf -t indexTable --auths exampleVis --path 'filename*jar' --search
 
 To count the number of direct children (directories and files) and descendants (children and children's descendants, directories and files), run the FileCount over the dirTable table.
 The results are written back to the same table. FileCount reads from and writes to Accumulo. This requires scan authorizations for the read and a visibility for the data written.
 In this example, the authorizations and visibility are set to the same value, exampleVis. See the [visibility example][vis] for more information on visibility and authorizations.
 
-    $ ./bin/runex dirlist.FileCount -i instance -z zookeepers -u username -p password -t dirTable --auths exampleVis
+    $ ./bin/runex dirlist.FileCount -c ./examples.conf -t dirTable --auths exampleVis
 
 ## Directory Table
 

--- a/docs/filedata.md
+++ b/docs/filedata.md
@@ -32,7 +32,7 @@ This example is coupled with the [dirlist example][dirlist].
 
 If you haven't already run the [dirlist example][dirlist], ingest a file with FileDataIngest.
 
-    $ ./bin/runex filedata.FileDataIngest -i instance -z zookeepers -u username -p password -t dataTable --auths exampleVis --chunk 1000 /path/to/accumulo/README.md
+    $ ./bin/runex filedata.FileDataIngest -c ./examples.conf -t dataTable --auths exampleVis --chunk 1000 /path/to/accumulo/README.md
 
 Open the accumulo shell and look at the data. The row is the MD5 hash of the file, which you can verify by running a command such as 'md5sum' on the file.
 
@@ -40,7 +40,7 @@ Open the accumulo shell and look at the data. The row is the MD5 hash of the fil
 
 Run the CharacterHistogram MapReduce to add some information about the file.
 
-    $ tool.sh target/accumulo-examples.jar org.apache.accumulo.examples.filedata.CharacterHistogram -i instance -z zookeepers -u username -p password -t dataTable --auths exampleVis --vis exampleVis
+    $ tool.sh target/accumulo-examples.jar org.apache.accumulo.examples.filedata.CharacterHistogram -c ./examples.conf -t dataTable --auths exampleVis --vis exampleVis
 
 Scan again to see the histogram stored in the 'info' column family.
 

--- a/docs/helloworld.md
+++ b/docs/helloworld.md
@@ -31,7 +31,7 @@ Create a table called 'hellotable':
 
 Launch a Java program that inserts data with a BatchWriter:
 
-    $ ./bin/runex helloworld.InsertWithBatchWriter -i instance -z zookeepers -u username -p password -t hellotable
+    $ ./bin/runex helloworld.InsertWithBatchWriter -c ./examples.conf -t hellotable
 
 On the accumulo status page at the URL below (where 'master' is replaced with the name or IP of your accumulo master), you should see 50K entries
 
@@ -44,4 +44,4 @@ To view the entries, use the shell to scan the table:
 
 You can also use a Java class to scan the table:
 
-    $ ./bin/runex helloworld.ReadData -i instance -z zookeepers -u username -p password -t hellotable --startKey row_0 --endKey row_1001
+    $ ./bin/runex helloworld.ReadData -c ./examples.conf -t hellotable --startKey row_0 --endKey row_1001

--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -30,7 +30,7 @@ reading the row at the same time a mutation is changing the row.
 Below, Interference Test is run without isolation enabled for 5000 iterations
 and it reports problems.
 
-    $ ./bin/runex isolation.InterferenceTest -i instance -z zookeepers -u username -p password -t isotest --iterations 5000
+    $ ./bin/runex isolation.InterferenceTest -c ./examples.conf -t isotest --iterations 5000
     ERROR Columns in row 053 had multiple values [53, 4553]
     ERROR Columns in row 061 had multiple values [561, 61]
     ERROR Columns in row 070 had multiple values [570, 1070]
@@ -43,7 +43,7 @@ and it reports problems.
 Below, Interference Test is run with isolation enabled for 5000 iterations and
 it reports no problems.
 
-    $ ./bin/runex isolation.InterferenceTest -i instance -z zookeepers -u username -p password -t isotest --iterations 5000 --isolated
+    $ ./bin/runex isolation.InterferenceTest -c ./examples.conf -t isotest --iterations 5000 --isolated
     finished
 
 

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -19,7 +19,7 @@ limitations under the License.
 This repository contains an integration test (IT) that runs all of the
 examples.  This can be used for testing Accumulo release candidates (RC). To
 run the IT against a RC add the following to `~/.m2/settings.xml` changing
-`XXXX` to the proper id.  
+`XXXX` to the proper id for a given RC.
 
 ```xml
  <profiles>

--- a/docs/release-testing.md
+++ b/docs/release-testing.md
@@ -1,0 +1,50 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Apache Accumulo Release Testing
+
+This repository contains an integration test (IT) that runs all of the
+examples.  This can be used for testing Accumulo release candidates (RC). To
+run the IT against a RC add the following to `~/.m2/settings.xml` changing
+`XXXX` to the proper id.  
+
+```xml
+ <profiles>
+   <profile>
+     <id>rcAccumulo</id>
+     <repositories>
+       <repository>
+         <id>accrc</id>
+         <name>accrcp</name>
+         <url>https://repository.apache.org/content/repositories/orgapacheaccumulo-XXXX</url>
+       </repository>
+     </repositories>
+     <pluginRepositories>
+       <pluginRepository>
+         <id>accrcp</id>
+         <name>accrcp</name>
+         <url>https://repository.apache.org/content/repositories/orgapacheaccumulo-XXX</url>
+       </pluginRepository>
+     </pluginRepositories>
+   </profile>
+ </profiles>
+```
+
+After adding that, you can run the following command in this repository to run the IT.
+
+```
+mvn clean verify -PrcAccumulo -Daccumulo.version=$ACCUMULO_RC_VERSION
+```

--- a/docs/sample.md
+++ b/docs/sample.md
@@ -88,7 +88,7 @@ failure and fixiing the problem with a compaction.
 The example above is replicated in a java program using the Accumulo API.
 Below is the program name and the command to run it.
 
-    ./bin/runex sample.SampleExample -i instance -z localhost -u root -p secret
+    ./bin/runex sample.SampleExample -c ./examples.conf
 
 The commands below look under the hood to give some insight into how this
 feature works.  The commands determine what files the sampex table is using.
@@ -166,13 +166,13 @@ shard table based on the column qualifier.
 After enabling sampling, the command below counts the number of documents in
 the sample containing the words `import` and `int`.     
 
-    $ ./bin/runex shard.Query --sample -i instance16 -z localhost -t shard -u root -p secret import int | fgrep '.java' | wc
+    $ ./bin/runex shard.Query --sample -c ./examples.conf -t shard import int | fgrep '.java' | wc
          11      11    1246
 
 The command below counts the total number of documents containing the words
 `import` and `int`.
 
-    $ ./bin/runex shard.Query -i instance16 -z localhost -t shard -u root -p secret import int | fgrep '.java' | wc
+    $ ./bin/runex shard.Query -c ./examples.conf -t shard import int | fgrep '.java' | wc
        1085    1085  118175
 
 The counts 11 out of 1085 total are around what would be expected for a modulus
@@ -188,4 +188,4 @@ To experiment with this iterator, use the following command.  The
 `--sampleCutoff` option below will cause the query to return nothing if based
 on the sample it appears a query would return more than 1000 documents.
 
-    $ ./bin/runex shard.Query --sampleCutoff 1000 -i instance16 -z localhost -t shard -u root -p secret import int | fgrep '.java' | wc
+    $ ./bin/runex shard.Query --sampleCutoff 1000 -c ./examples.conf -t shard import int | fgrep '.java' | wc

--- a/docs/shard.md
+++ b/docs/shard.md
@@ -32,11 +32,11 @@ To run these example programs, create two tables like below.
 After creating the tables, index some files. The following command indexes all of the java files in the Accumulo source code.
 
     $ cd /local/username/workspace/accumulo/
-    $ find core/src server/src -name "*.java" | xargs ./bin/runex shard.Index -i instance -z zookeepers -t shard -u username -p password --partitions 30
+    $ find core/src server/src -name "*.java" | xargs ./bin/runex shard.Index -c ./examples.conf -t shard --partitions 30
 
 The following command queries the index to find all files containing 'foo' and 'bar'.
 
-    $ ./bin/runex shard.Query -i instance -z zookeepers -t shard -u username -p password foo bar
+    $ ./bin/runex shard.Query -c ./examples.conf -t shard foo bar
     /local/username/workspace/accumulo/src/core/src/test/java/accumulo/core/security/ColumnVisibilityTest.java
     /local/username/workspace/accumulo/src/core/src/test/java/accumulo/core/client/mock/MockConnectorTest.java
     /local/username/workspace/accumulo/src/core/src/test/java/accumulo/core/security/VisibilityEvaluatorTest.java
@@ -51,12 +51,12 @@ The following command queries the index to find all files containing 'foo' and '
 
 In order to run ContinuousQuery, we need to run Reverse.java to populate doc2term.
 
-    $ ./bin/runex shard.Reverse -i instance -z zookeepers --shardTable shard --doc2Term doc2term -u username -p password
+    $ ./bin/runex shard.Reverse -c ./examples.conf --shardTable shard --doc2Term doc2term
 
 Below ContinuousQuery is run using 5 terms. So it selects 5 random terms from each document, then it continually
 randomly selects one set of 5 terms and queries. It prints the number of matching documents and the time in seconds.
 
-    $ ./bin/runex shard.ContinuousQuery -i instance -z zookeepers --shardTable shard --doc2Term doc2term -u username -p password --terms 5
+    $ ./bin/runex shard.ContinuousQuery -c ./examples.conf --shardTable shard --doc2Term doc2term --terms 5
     [public, core, class, binarycomparable, b] 2  0.081
     [wordtodelete, unindexdocument, doctablename, putdelete, insert] 1  0.041
     [import, columnvisibilityinterpreterfactory, illegalstateexception, cv, columnvisibility] 1  0.049

--- a/docs/tabletofile.md
+++ b/docs/tabletofile.md
@@ -40,7 +40,7 @@ write the key/value pairs to a file in HDFS.
 
 The following will extract the rows containing the column "cf:cq":
 
-    $ tool.sh target/accumulo-examples.jar org.apache.accumulo.examples.mapreduce.TableToFile -u user -p passwd -i instance -t input --columns cf:cq --output /tmp/output
+    $ tool.sh target/accumulo-examples.jar org.apache.accumulo.examples.mapreduce.TableToFile -c ./examples.conf -t input --columns cf:cq --output /tmp/output
 
     $ hadoop fs -ls /tmp/output
     -rw-r--r--   1 username supergroup          0 2013-01-10 14:44 /tmp/output/_SUCCESS

--- a/docs/terasort.md
+++ b/docs/terasort.md
@@ -23,7 +23,7 @@ hadoop terasort benchmark.
 To run this example you run it with arguments describing the amount of data:
 
     $ tool.sh target/accumulo-examples.jar org.apache.accumulo.examples.mapreduce.TeraSortIngest \
-    -i instance -z zookeepers -u user -p password \
+    -c ./examples.conf \
     --count 10 \
     --minKeySize 10 \
     --maxKeySize 10 \

--- a/examples.conf.template
+++ b/examples.conf.template
@@ -21,3 +21,7 @@ instance.zookeeper.host=localhost:2181
 instance.name=your-instance-name
 accumulo.examples.principal=root
 accumulo.examples.password=secret
+
+# Currently the examples only support authentication via username and password.
+# Kerberos authentication is currently not supported in the utility code used
+# by all of the examples.

--- a/examples.conf.template
+++ b/examples.conf.template
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Properties prefixed with accumulo.examples are not general Accumulo properties
 # and are only used by example code in this repository. All other properties are
 # general Accumulo properties parsed by Accumulo's ClientConfiguration

--- a/examples.conf.template
+++ b/examples.conf.template
@@ -21,11 +21,3 @@ instance.zookeeper.host=localhost:2181
 instance.name=your-instance-name
 accumulo.examples.principal=root
 accumulo.examples.password=secret
-
-# The following can be set when using Kerberos.   When set the password propety
-# is ignored.
-
-# instance.rpc.sasl.enabled=true
-# rpc.sasl.qop=auth
-# kerberos.server.primary=accumulo
-# accumulo.examples.keytab=<keytab file location>

--- a/examples.conf.template
+++ b/examples.conf.template
@@ -1,0 +1,16 @@
+# Properties prefixed with accumulo.examples are not general Accumulo properties
+# and are only used by example code in this repository. All other properties are
+# general Accumulo properties parsed by Accumulo's ClientConfiguration
+
+instance.zookeeper.host=localhost:2181
+instance.name=your-instance-name
+accumulo.examples.principal=root
+accumulo.examples.password=secret
+
+# The following can be set when using Kerberos.   When set the password propety
+# is ignored.
+
+# instance.rpc.sasl.enabled=true
+# rpc.sasl.qop=auth
+# kerberos.server.primary=accumulo
+# accumulo.examples.keytab=<keytab file location>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,20 @@
         <configuration>
           <cleanupDaemonThreads>false</cleanupDaemonThreads>
         </configuration>
-      </plugin>  
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>0.12</version>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/org/apache/accumulo/examples/cli/BatchScannerOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/BatchScannerOpts.java
@@ -1,0 +1,14 @@
+package org.apache.accumulo.examples.cli;
+
+import org.apache.accumulo.examples.cli.ClientOpts.TimeConverter;
+
+import com.beust.jcommander.Parameter;
+
+public class BatchScannerOpts {
+  @Parameter(names = "--scanThreads", description = "Number of threads to use when batch scanning")
+  public Integer scanThreads = 10;
+
+  @Parameter(names = "--scanTimeout", converter = TimeConverter.class, description = "timeout used to fail a batch scan")
+  public Long scanTimeout = Long.MAX_VALUE;
+
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/BatchScannerOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/BatchScannerOpts.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.examples.cli;
 
 import org.apache.accumulo.examples.cli.ClientOpts.TimeConverter;

--- a/src/main/java/org/apache/accumulo/examples/cli/BatchWriterOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/BatchWriterOpts.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.examples.cli;
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/org/apache/accumulo/examples/cli/BatchWriterOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/BatchWriterOpts.java
@@ -1,0 +1,35 @@
+package org.apache.accumulo.examples.cli;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.accumulo.core.client.BatchWriterConfig;
+import org.apache.accumulo.examples.cli.ClientOpts.MemoryConverter;
+import org.apache.accumulo.examples.cli.ClientOpts.TimeConverter;
+
+import com.beust.jcommander.Parameter;
+
+public class BatchWriterOpts {
+  private static final BatchWriterConfig BWDEFAULTS = new BatchWriterConfig();
+
+  @Parameter(names = "--batchThreads", description = "Number of threads to use when writing large batches")
+  public Integer batchThreads = BWDEFAULTS.getMaxWriteThreads();
+
+  @Parameter(names = "--batchLatency", converter = TimeConverter.class, description = "The maximum time to wait before flushing data to servers when writing")
+  public Long batchLatency = BWDEFAULTS.getMaxLatency(TimeUnit.MILLISECONDS);
+
+  @Parameter(names = "--batchMemory", converter = MemoryConverter.class, description = "memory used to batch data when writing")
+  public Long batchMemory = BWDEFAULTS.getMaxMemory();
+
+  @Parameter(names = "--batchTimeout", converter = TimeConverter.class, description = "timeout used to fail a batch write")
+  public Long batchTimeout = BWDEFAULTS.getTimeout(TimeUnit.MILLISECONDS);
+
+  public BatchWriterConfig getBatchWriterConfig() {
+    BatchWriterConfig config = new BatchWriterConfig();
+    config.setMaxWriteThreads(this.batchThreads);
+    config.setMaxLatency(this.batchLatency, TimeUnit.MILLISECONDS);
+    config.setMaxMemory(this.batchMemory);
+    config.setTimeout(this.batchTimeout, TimeUnit.MILLISECONDS);
+    return config;
+  }
+
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/ClientOnDefaultTable.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ClientOnDefaultTable.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.examples.cli;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/cli/ClientOnDefaultTable.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ClientOnDefaultTable.java
@@ -1,0 +1,20 @@
+package org.apache.accumulo.examples.cli;
+
+import com.beust.jcommander.Parameter;
+
+public class ClientOnDefaultTable extends ClientOpts {
+  @Parameter(names = "--table", description = "table to use")
+  private String tableName;
+
+  public ClientOnDefaultTable(String table) {
+    this.tableName = table;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  public void setTableName(String tableName) {
+    this.tableName = tableName;
+  }
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/ClientOnRequiredTable.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ClientOnRequiredTable.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.examples.cli;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/cli/ClientOnRequiredTable.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ClientOnRequiredTable.java
@@ -1,0 +1,12 @@
+package org.apache.accumulo.examples.cli;
+
+import com.beust.jcommander.Parameter;
+
+public class ClientOnRequiredTable extends ClientOpts {
+  @Parameter(names = {"-t", "--table"}, required = true, description = "table to use")
+  private String tableName;
+
+  public String getTableName() {
+    return tableName;
+  }
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/ClientOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ClientOpts.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.examples.cli;
 
 import java.io.File;

--- a/src/main/java/org/apache/accumulo/examples/cli/ClientOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ClientOpts.java
@@ -1,0 +1,127 @@
+package org.apache.accumulo.examples.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+
+import org.apache.accumulo.core.client.AccumuloException;
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.ClientConfiguration;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.ZooKeeperInstance;
+import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
+import org.apache.accumulo.core.client.security.tokens.KerberosToken;
+import org.apache.accumulo.core.client.security.tokens.PasswordToken;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.Parameter;
+
+public class ClientOpts extends Help {
+
+  public static class AuthConverter implements IStringConverter<Authorizations> {
+    @Override
+    public Authorizations convert(String value) {
+      return new Authorizations(value.split(","));
+    }
+  }
+
+  public static class VisibilityConverter implements IStringConverter<ColumnVisibility> {
+    @Override
+    public ColumnVisibility convert(String value) {
+      return new ColumnVisibility(value);
+    }
+  }
+
+  public static class TimeConverter implements IStringConverter<Long> {
+    @Override
+    public Long convert(String value) {
+      if(value.matches("[0-9]+"))
+        value = "PT"+value+"S"; //if only numbers then assume seconds
+      return Duration.parse(value).toMillis();
+    }
+  }
+
+  public static class MemoryConverter implements IStringConverter<Long> {
+    @Override
+    public Long convert(String str) {
+      try {
+        char lastChar = str.charAt(str.length() - 1);
+        int multiplier = 0;
+        switch (Character.toUpperCase(lastChar)) {
+          case 'G':
+            multiplier += 10;
+          case 'M':
+            multiplier += 10;
+          case 'K':
+            multiplier += 10;
+          case 'B':
+            break;
+          default:
+            return Long.parseLong(str);
+        }
+        return Long.parseLong(str.substring(0, str.length() - 1)) << multiplier;
+      } catch (Exception ex) {
+        throw new IllegalArgumentException("The value '" + str + "' is not a valid memory setting. A valid value would a number "
+            + "possibily followed by an optional 'G', 'M', 'K', or 'B'.");
+      }
+    }
+  }
+
+  public static class PropertiesConverter implements IStringConverter<Configuration> {
+    @Override
+    public Configuration convert(String filename) {
+      try {
+        return new PropertiesConfiguration(filename);
+      } catch (ConfigurationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  @Parameter(names = {"-c", "--conf"}, required = true, converter = PropertiesConverter.class,
+      description = "Config file for connecting to Accumulo.  See README.md for details.")
+  private Configuration config = null;
+
+  @Parameter(names = {"-auths", "--auths"}, converter = AuthConverter.class, description = "the authorizations to use when reading or writing")
+  public Authorizations auths = Authorizations.EMPTY;
+
+  public Connector getConnector() {
+    try {
+      ZooKeeperInstance zki = new ZooKeeperInstance(config);
+      return zki.getConnector(getPrincipal(), getToken());
+    } catch (AccumuloException | AccumuloSecurityException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public ClientConfiguration getClientConfiguration() {
+    return new ClientConfiguration(config);
+  }
+
+  public String getPrincipal() {
+    return config.getString("accumulo.examples.principal", "root");
+  }
+
+  public AuthenticationToken getToken() {
+    if (config.containsKey("instance.rpc.sasl.enabled")) {
+      try {
+        if (config.containsKey("accumulo.examples.keytab")) {
+          String keytab = config.getString("accumulo.examples.keytab");
+          return new KerberosToken(getPrincipal(), new File(keytab));
+        } else {
+          return new KerberosToken(getPrincipal());
+        }
+      } catch (IOException ioe) {
+        throw new UncheckedIOException(ioe);
+      }
+    } else {
+      return new PasswordToken(config.getString("accumulo.examples.password", "secret"));
+    }
+  }
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/ClientOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ClientOpts.java
@@ -16,9 +16,6 @@
  */
 package org.apache.accumulo.examples.cli;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.time.Duration;
 
 import org.apache.accumulo.core.client.AccumuloException;
@@ -27,7 +24,6 @@ import org.apache.accumulo.core.client.ClientConfiguration;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.ZooKeeperInstance;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
-import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
@@ -125,19 +121,6 @@ public class ClientOpts extends Help {
   }
 
   public AuthenticationToken getToken() {
-    if (config.containsKey("instance.rpc.sasl.enabled")) {
-      try {
-        if (config.containsKey("accumulo.examples.keytab")) {
-          String keytab = config.getString("accumulo.examples.keytab");
-          return new KerberosToken(getPrincipal(), new File(keytab));
-        } else {
-          return new KerberosToken(getPrincipal());
-        }
-      } catch (IOException ioe) {
-        throw new UncheckedIOException(ioe);
-      }
-    } else {
-      return new PasswordToken(config.getString("accumulo.examples.password", "secret"));
-    }
+    return new PasswordToken(config.getString("accumulo.examples.password", "secret"));
   }
 }

--- a/src/main/java/org/apache/accumulo/examples/cli/Help.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/Help.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.examples.cli;
 
 import com.beust.jcommander.JCommander;

--- a/src/main/java/org/apache/accumulo/examples/cli/Help.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/Help.java
@@ -1,0 +1,37 @@
+package org.apache.accumulo.examples.cli;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+
+public class Help {
+  @Parameter(names = {"-h", "-?", "--help", "-help"}, help = true)
+  public boolean help = false;
+
+  public void parseArgs(String programName, String[] args, Object... others) {
+    JCommander commander = new JCommander();
+    commander.addObject(this);
+    for (Object other : others)
+      commander.addObject(other);
+    commander.setProgramName(programName);
+    try {
+      commander.parse(args);
+    } catch (ParameterException ex) {
+      commander.usage();
+      exitWithError(ex.getMessage(), 1);
+    }
+    if (help) {
+      commander.usage();
+      exit(0);
+    }
+  }
+
+  public void exit(int status) {
+    System.exit(status);
+  }
+
+  public void exitWithError(String message, int status) {
+    System.err.println(message);
+    exit(status);
+  }
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/MapReduceClientOnDefaultTable.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/MapReduceClientOnDefaultTable.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.examples.cli;
+
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
+import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
+import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
+import org.apache.hadoop.mapreduce.Job;
+
+import com.beust.jcommander.Parameter;
+
+public class MapReduceClientOnDefaultTable extends MapReduceClientOpts {
+  @Parameter(names = "--table", description = "table to use")
+  public String tableName;
+
+  public MapReduceClientOnDefaultTable(String table) {
+    this.tableName = table;
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+
+  @Override
+  public void setAccumuloConfigs(Job job) throws AccumuloSecurityException {
+    super.setAccumuloConfigs(job);
+    final String tableName = getTableName();
+    final String principal = getPrincipal();
+    final AuthenticationToken token = getToken();
+    AccumuloInputFormat.setConnectorInfo(job, principal, token);
+    AccumuloInputFormat.setInputTableName(job, tableName);
+    AccumuloInputFormat.setScanAuthorizations(job, auths);
+    AccumuloOutputFormat.setConnectorInfo(job, principal, token);
+    AccumuloOutputFormat.setCreateTables(job, true);
+    AccumuloOutputFormat.setDefaultTableName(job, tableName);
+  }
+
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/MapReduceClientOnRequiredTable.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/MapReduceClientOnRequiredTable.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.examples.cli;
+
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
+import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
+import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
+import org.apache.hadoop.mapreduce.Job;
+
+import com.beust.jcommander.Parameter;
+
+public class MapReduceClientOnRequiredTable extends MapReduceClientOpts {
+
+  @Parameter(names = {"-t", "--table"}, required = true, description = "table to use")
+  private String tableName;
+
+  @Parameter(names = {"-tf", "--tokenFile"}, description = "File in hdfs containing the user's authentication token create with \"bin/accumulo create-token\"")
+  private String tokenFile = "";
+
+  @Override
+  public void setAccumuloConfigs(Job job) throws AccumuloSecurityException {
+    super.setAccumuloConfigs(job);
+
+    final String principal = getPrincipal(), tableName = getTableName();
+
+    if (tokenFile.isEmpty()) {
+      AuthenticationToken token = getToken();
+      AccumuloInputFormat.setConnectorInfo(job, principal, token);
+      AccumuloOutputFormat.setConnectorInfo(job, principal, token);
+    } else {
+      AccumuloInputFormat.setConnectorInfo(job, principal, tokenFile);
+      AccumuloOutputFormat.setConnectorInfo(job, principal, tokenFile);
+    }
+    AccumuloInputFormat.setInputTableName(job, tableName);
+    AccumuloInputFormat.setScanAuthorizations(job, auths);
+    AccumuloOutputFormat.setCreateTables(job, true);
+    AccumuloOutputFormat.setDefaultTableName(job, tableName);
+  }
+
+  public String getTableName() {
+    return tableName;
+  }
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/MapReduceClientOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/MapReduceClientOpts.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.accumulo.examples.cli;
+
+import org.apache.accumulo.core.client.AccumuloSecurityException;
+import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.core.client.admin.DelegationTokenConfig;
+import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
+import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
+import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
+import org.apache.accumulo.core.client.security.tokens.KerberosToken;
+import org.apache.accumulo.core.security.SystemPermission;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Adds some MR awareness to the ClientOpts
+ */
+public class MapReduceClientOpts extends ClientOpts {
+  private static final Logger log = LoggerFactory.getLogger(MapReduceClientOpts.class);
+
+  public void setAccumuloConfigs(Job job) throws AccumuloSecurityException {
+    AccumuloInputFormat.setZooKeeperInstance(job, this.getClientConfiguration());
+    AccumuloOutputFormat.setZooKeeperInstance(job, this.getClientConfiguration());
+  }
+
+  @Override
+  public AuthenticationToken getToken() {
+    AuthenticationToken authToken = super.getToken();
+    // For MapReduce, Kerberos credentials don't make it to the Mappers and Reducers,
+    // so we need to request a delegation token and use that instead.
+    if (authToken instanceof KerberosToken) {
+      log.info("Received KerberosToken, fetching DelegationToken for MapReduce");
+
+      try {
+        UserGroupInformation user = UserGroupInformation.getCurrentUser();
+        if (!user.hasKerberosCredentials()) {
+          throw new IllegalStateException("Expected current user to have Kerberos credentials");
+        }
+
+        String newPrincipal = user.getUserName();
+        log.info("Obtaining delegation token for {}", newPrincipal);
+
+        Connector conn = getConnector();
+
+        // Do the explicit check to see if the user has the permission to get a delegation token
+        if (!conn.securityOperations().hasSystemPermission(conn.whoami(), SystemPermission.OBTAIN_DELEGATION_TOKEN)) {
+          log.error(
+              "{} doesn't have the {} SystemPermission neccesary to obtain a delegation token. MapReduce tasks cannot automatically use the client's"
+                  + " credentials on remote servers. Delegation tokens provide a means to run MapReduce without distributing the user's credentials.",
+              user.getUserName(), SystemPermission.OBTAIN_DELEGATION_TOKEN.name());
+          throw new IllegalStateException(conn.whoami() + " does not have permission to obtain a delegation token");
+        }
+
+        // Get the delegation token from Accumulo
+        return conn.securityOperations().getDelegationToken(new DelegationTokenConfig());
+      } catch (Exception e) {
+        final String msg = "Failed to acquire DelegationToken for use with MapReduce";
+        log.error(msg, e);
+        throw new RuntimeException(msg, e);
+      }
+    }
+    return authToken;
+  }
+}

--- a/src/main/java/org/apache/accumulo/examples/cli/ScannerOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ScannerOpts.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.examples.cli;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/cli/ScannerOpts.java
+++ b/src/main/java/org/apache/accumulo/examples/cli/ScannerOpts.java
@@ -1,0 +1,8 @@
+package org.apache.accumulo.examples.cli;
+
+import com.beust.jcommander.Parameter;
+
+public class ScannerOpts {
+  @Parameter(names = "--scanBatchSize", description = "the number of key-values to pull during a scan")
+  public int scanBatchSize = 1000;
+}

--- a/src/main/java/org/apache/accumulo/examples/client/Flush.java
+++ b/src/main/java/org/apache/accumulo/examples/client/Flush.java
@@ -16,8 +16,8 @@
  */
 package org.apache.accumulo.examples.client;
 
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 
 /**
  * Simple example for using tableOperations() (like create, delete, flush, etc).

--- a/src/main/java/org/apache/accumulo/examples/client/RandomBatchScanner.java
+++ b/src/main/java/org/apache/accumulo/examples/client/RandomBatchScanner.java
@@ -24,8 +24,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.accumulo.core.cli.BatchScannerOpts;
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchScanner;
@@ -34,6 +32,8 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.BatchScannerOpts;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/apache/accumulo/examples/client/RandomBatchWriter.java
+++ b/src/main/java/org/apache/accumulo/examples/client/RandomBatchWriter.java
@@ -22,8 +22,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -35,6 +33,8 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.TabletId;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/client/ReadWriteExample.java
+++ b/src/main/java/org/apache/accumulo/examples/client/ReadWriteExample.java
@@ -20,8 +20,6 @@ import java.util.Map.Entry;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.apache.accumulo.core.cli.ClientOnDefaultTable;
-import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
@@ -34,6 +32,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.util.ByteArraySet;
+import org.apache.accumulo.examples.cli.ClientOnDefaultTable;
+import org.apache.accumulo.examples.cli.ScannerOpts;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.IStringConverter;
@@ -54,15 +54,15 @@ public class ReadWriteExample {
   }
 
   static class Opts extends ClientOnDefaultTable {
-    @Parameter(names = {"-C", "--createtable"}, description = "create table before doing anything")
+    @Parameter(names = {"--createtable"}, description = "create table before doing anything")
     boolean createtable = false;
-    @Parameter(names = {"-D", "--deletetable"}, description = "delete table when finished")
+    @Parameter(names = {"--deletetable"}, description = "delete table when finished")
     boolean deletetable = false;
-    @Parameter(names = {"-c", "--create"}, description = "create entries before any deletes")
+    @Parameter(names = {"--create"}, description = "create entries before any deletes")
     boolean createEntries = false;
-    @Parameter(names = {"-r", "--read"}, description = "read entries after any creates/deletes")
+    @Parameter(names = {"--read"}, description = "read entries after any creates/deletes")
     boolean readEntries = false;
-    @Parameter(names = {"-d", "--delete"}, description = "delete entries after any creates")
+    @Parameter(names = {"--delete"}, description = "delete entries after any creates")
     boolean deleteEntries = false;
     @Parameter(names = {"--durability"}, description = "durability used for writes (none, log, flush or sync)", converter = DurabilityConverter.class)
     Durability durability = Durability.DEFAULT;

--- a/src/main/java/org/apache/accumulo/examples/client/RowOperations.java
+++ b/src/main/java/org/apache/accumulo/examples/client/RowOperations.java
@@ -20,9 +20,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOpts;
-import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -36,6 +33,9 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOpts;
+import org.apache.accumulo.examples.cli.ScannerOpts;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/apache/accumulo/examples/client/SequentialBatchWriter.java
+++ b/src/main/java/org/apache/accumulo/examples/client/SequentialBatchWriter.java
@@ -16,8 +16,6 @@
  */
 package org.apache.accumulo.examples.client;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -26,6 +24,8 @@ import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 
 import com.beust.jcommander.Parameter;
 

--- a/src/main/java/org/apache/accumulo/examples/client/TraceDumpExample.java
+++ b/src/main/java/org/apache/accumulo/examples/client/TraceDumpExample.java
@@ -16,8 +16,6 @@
  */
 package org.apache.accumulo.examples.client;
 
-import org.apache.accumulo.core.cli.ClientOnDefaultTable;
-import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
@@ -25,6 +23,8 @@ import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.security.TablePermission;
+import org.apache.accumulo.examples.cli.ClientOnDefaultTable;
+import org.apache.accumulo.examples.cli.ScannerOpts;
 import org.apache.accumulo.tracer.TraceDump;
 import org.apache.accumulo.tracer.TraceDump.Printer;
 import org.apache.hadoop.io.Text;

--- a/src/main/java/org/apache/accumulo/examples/client/TracingExample.java
+++ b/src/main/java/org/apache/accumulo/examples/client/TracingExample.java
@@ -21,8 +21,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.ClientOnDefaultTable;
-import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -35,6 +33,8 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.trace.DistributedTrace;
+import org.apache.accumulo.examples.cli.ClientOnDefaultTable;
+import org.apache.accumulo.examples.cli.ScannerOpts;
 import org.apache.htrace.Sampler;
 import org.apache.htrace.Trace;
 import org.apache.htrace.TraceScope;
@@ -52,13 +52,13 @@ public class TracingExample {
   private static final String DEFAULT_TABLE_NAME = "test";
 
   static class Opts extends ClientOnDefaultTable {
-    @Parameter(names = {"-C", "--createtable"}, description = "create table before doing anything")
+    @Parameter(names = {"--createtable"}, description = "create table before doing anything")
     boolean createtable = false;
-    @Parameter(names = {"-D", "--deletetable"}, description = "delete table when finished")
+    @Parameter(names = {"--deletetable"}, description = "delete table when finished")
     boolean deletetable = false;
-    @Parameter(names = {"-c", "--create"}, description = "create entries before any deletes")
+    @Parameter(names = {"--create"}, description = "create entries before any deletes")
     boolean createEntries = false;
-    @Parameter(names = {"-r", "--read"}, description = "read entries after any creates/deletes")
+    @Parameter(names = {"--read"}, description = "read entries after any creates/deletes")
     boolean readEntries = false;
 
     public Opts() {

--- a/src/main/java/org/apache/accumulo/examples/dirlist/Ingest.java
+++ b/src/main/java/org/apache/accumulo/examples/dirlist/Ingest.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOpts;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -31,6 +29,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.LongCombiner;
 import org.apache.accumulo.core.iterators.TypedValueCombiner.Encoder;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOpts;
 import org.apache.accumulo.examples.filedata.ChunkCombiner;
 import org.apache.accumulo.examples.filedata.FileDataIngest;
 import org.apache.hadoop.io.Text;

--- a/src/main/java/org/apache/accumulo/examples/dirlist/QueryUtil.java
+++ b/src/main/java/org/apache/accumulo/examples/dirlist/QueryUtil.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
@@ -32,6 +31,7 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.RegExFilter;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/dirlist/Viewer.java
+++ b/src/main/java/org/apache/accumulo/examples/dirlist/Viewer.java
@@ -104,7 +104,7 @@ public class Viewer extends JFrame implements TreeSelectionListener, TreeExpansi
     setSize(1000, 800);
     setDefaultCloseOperation(EXIT_ON_CLOSE);
     q = new QueryUtil(opts);
-    fdq = new FileDataQuery(opts.instance, opts.zookeepers, opts.getPrincipal(), opts.getToken(), opts.dataTable, opts.auths);
+    fdq = new FileDataQuery(opts.getConnector(), opts.dataTable, opts.auths);
     this.topPath = opts.path;
   }
 

--- a/src/main/java/org/apache/accumulo/examples/filedata/CharacterHistogram.java
+++ b/src/main/java/org/apache/accumulo/examples/filedata/CharacterHistogram.java
@@ -22,13 +22,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.SummingArrayCombiner;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.io.Text;

--- a/src/main/java/org/apache/accumulo/examples/filedata/FileDataIngest.java
+++ b/src/main/java/org/apache/accumulo/examples/filedata/FileDataIngest.java
@@ -24,8 +24,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -35,6 +33,8 @@ import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.ColumnVisibility;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;
@@ -197,6 +197,7 @@ public class FileDataIngest {
       fdi.insertFileData(filename, bw);
     }
     bw.close();
-    opts.stopTracing();
+    //TODO
+    //opts.stopTracing();
   }
 }

--- a/src/main/java/org/apache/accumulo/examples/filedata/FileDataQuery.java
+++ b/src/main/java/org/apache/accumulo/examples/filedata/FileDataQuery.java
@@ -23,12 +23,9 @@ import java.util.Map.Entry;
 
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
-import org.apache.accumulo.core.client.ClientConfiguration;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
-import org.apache.accumulo.core.client.ZooKeeperInstance;
-import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
@@ -40,15 +37,12 @@ import org.apache.accumulo.core.util.PeekingIterator;
  * instructions.
  */
 public class FileDataQuery {
-  private Connector conn = null;
   List<Entry<Key,Value>> lastRefs;
   private ChunkInputStream cis;
   Scanner scanner;
 
-  public FileDataQuery(String instanceName, String zooKeepers, String user, AuthenticationToken token, String tableName, Authorizations auths)
+  public FileDataQuery(Connector conn, String tableName, Authorizations auths)
       throws AccumuloException, AccumuloSecurityException, TableNotFoundException {
-    ZooKeeperInstance instance = new ZooKeeperInstance(ClientConfiguration.loadDefault().withInstance(instanceName).withZkHosts(zooKeepers));
-    conn = instance.getConnector(user, token);
     lastRefs = new ArrayList<>();
     cis = new ChunkInputStream();
     scanner = conn.createScanner(tableName, auths);

--- a/src/main/java/org/apache/accumulo/examples/helloworld/InsertWithBatchWriter.java
+++ b/src/main/java/org/apache/accumulo/examples/helloworld/InsertWithBatchWriter.java
@@ -16,8 +16,6 @@
  */
 package org.apache.accumulo.examples.helloworld;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
@@ -28,6 +26,8 @@ import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 
 /**

--- a/src/main/java/org/apache/accumulo/examples/helloworld/ReadData.java
+++ b/src/main/java/org/apache/accumulo/examples/helloworld/ReadData.java
@@ -19,8 +19,6 @@ package org.apache.accumulo.examples.helloworld;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
-import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
@@ -29,6 +27,8 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
+import org.apache.accumulo.examples.cli.ScannerOpts;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/apache/accumulo/examples/isolation/InterferenceTest.java
+++ b/src/main/java/org/apache/accumulo/examples/isolation/InterferenceTest.java
@@ -19,8 +19,6 @@ package org.apache.accumulo.examples.isolation;
 import java.util.HashSet;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IsolatedScanner;
@@ -30,6 +28,8 @@ import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/NGramIngest.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/NGramIngest.java
@@ -20,10 +20,10 @@ import java.io.IOException;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/RegexExample.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/RegexExample.java
@@ -18,12 +18,12 @@ package org.apache.accumulo.examples.mapreduce;
 
 import java.io.IOException;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.RegExFilter;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/RowHash.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/RowHash.java
@@ -20,13 +20,13 @@ import java.io.IOException;
 import java.util.Base64;
 import java.util.Collections;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
 import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.util.Pair;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.io.MD5Hash;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/TableToFile.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/TableToFile.java
@@ -21,13 +21,13 @@ import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashSet;
 import java.util.Map;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.util.Pair;
 import org.apache.accumulo.core.util.format.DefaultFormatter;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/TeraSortIngest.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/TeraSortIngest.java
@@ -25,11 +25,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.io.LongWritable;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/UniqueColumns.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/UniqueColumns.java
@@ -20,12 +20,12 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.mapreduce.AccumuloInputFormat;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/WordCount.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/WordCount.java
@@ -18,10 +18,10 @@ package org.apache.accumulo.examples.mapreduce;
 
 import java.io.IOException;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.mapreduce.AccumuloOutputFormat;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.Path;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/BulkIngestExample.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/BulkIngestExample.java
@@ -22,13 +22,13 @@ import java.io.PrintStream;
 import java.util.Base64;
 import java.util.Collection;
 
-import org.apache.accumulo.core.cli.MapReduceClientOnRequiredTable;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.mapreduce.AccumuloFileOutputFormat;
 import org.apache.accumulo.core.client.mapreduce.lib.partition.RangePartitioner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.util.TextUtil;
+import org.apache.accumulo.examples.cli.MapReduceClientOnRequiredTable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileSystem;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/SetupTable.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/SetupTable.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
 
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.Connector;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/VerifyIngest.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/VerifyIngest.java
@@ -19,7 +19,6 @@ package org.apache.accumulo.examples.mapreduce.bulk;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
@@ -28,6 +27,7 @@ import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/org/apache/accumulo/examples/sample/SampleExample.java
+++ b/src/main/java/org/apache/accumulo/examples/sample/SampleExample.java
@@ -20,8 +20,6 @@ package org.apache.accumulo.examples.sample;
 import java.util.Collections;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOnDefaultTable;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.SampleNotPresentException;
@@ -34,6 +32,8 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOnDefaultTable;
 import org.apache.accumulo.examples.client.RandomBatchWriter;
 import org.apache.accumulo.examples.shard.CutoffIntersectingIterator;
 

--- a/src/main/java/org/apache/accumulo/examples/shard/ContinuousQuery.java
+++ b/src/main/java/org/apache/accumulo/examples/shard/ContinuousQuery.java
@@ -23,8 +23,6 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.accumulo.core.cli.BatchScannerOpts;
-import org.apache.accumulo.core.cli.ClientOpts;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -33,6 +31,8 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.IntersectingIterator;
+import org.apache.accumulo.examples.cli.BatchScannerOpts;
+import org.apache.accumulo.examples.cli.ClientOpts;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/shard/Index.java
+++ b/src/main/java/org/apache/accumulo/examples/shard/Index.java
@@ -22,11 +22,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/shard/Query.java
+++ b/src/main/java/org/apache/accumulo/examples/shard/Query.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.accumulo.core.cli.BatchScannerOpts;
-import org.apache.accumulo.core.cli.ClientOnRequiredTable;
 import org.apache.accumulo.core.client.BatchScanner;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
@@ -32,6 +30,8 @@ import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.user.IntersectingIterator;
+import org.apache.accumulo.examples.cli.BatchScannerOpts;
+import org.apache.accumulo.examples.cli.ClientOnRequiredTable;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;

--- a/src/main/java/org/apache/accumulo/examples/shard/Reverse.java
+++ b/src/main/java/org/apache/accumulo/examples/shard/Reverse.java
@@ -18,15 +18,15 @@ package org.apache.accumulo.examples.shard;
 
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ClientOpts;
-import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ClientOpts;
+import org.apache.accumulo.examples.cli.ScannerOpts;
 import org.apache.hadoop.io.Text;
 
 import com.beust.jcommander.Parameter;

--- a/src/test/java/org/apache/accumulo/examples/ExamplesIT.java
+++ b/src/test/java/org/apache/accumulo/examples/ExamplesIT.java
@@ -48,7 +48,6 @@ import org.apache.accumulo.core.client.Connector;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.security.tokens.AuthenticationToken;
-import org.apache.accumulo.core.client.security.tokens.KerberosToken;
 import org.apache.accumulo.core.client.security.tokens.PasswordToken;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.core.data.Key;
@@ -134,19 +133,7 @@ public class ExamplesIT extends AccumuloClusterHarness {
     String instance = c.getInstance().getInstanceName();
     String keepers = c.getInstance().getZooKeepers();
     AuthenticationToken token = getAdminToken();
-    if (token instanceof KerberosToken) {
-      String keytab = getAdminUser().getKeytab().getAbsolutePath();
-      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(getConnectionFile()))) {
-        writer.write("instance.zookeeper.host=" + keepers + "\n");
-        writer.write("instance.name=" + instance + "\n");
-        writer.write("accumulo.examples.principal=" + user + "\n");
-        writer.write("instance.rpc.sasl.enabled=true\n");
-        writer.write("rpc.sasl.qop=auth\n");
-        writer.write("kerberos.server.primary=accumulo\n");
-        writer.write("accumulo.examples.keytab=" + keytab + "\n");
-
-      }
-    } else if (token instanceof PasswordToken) {
+    if (token instanceof PasswordToken) {
       String passwd = new String(((PasswordToken) getAdminToken()).getPassword(), UTF_8);
       writeConnectionFile(getConnectionFile(), instance, keepers, user, passwd);
     } else {

--- a/src/test/java/org/apache/accumulo/examples/ExamplesIT.java
+++ b/src/test/java/org/apache/accumulo/examples/ExamplesIT.java
@@ -23,8 +23,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -98,7 +101,6 @@ import org.apache.hadoop.util.Tool;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,17 +115,11 @@ public class ExamplesIT extends AccumuloClusterHarness {
   private static final String auths = "A,B";
 
   Connector c;
-  String instance;
-  String keepers;
-  String user;
-  String passwd;
-  String keytab;
   BatchWriter bw;
   IteratorSetting is;
   String dir;
   FileSystem fs;
   Authorizations origAuths;
-  boolean saslEnabled;
 
   @Override
   public void configureMiniCluster(MiniAccumuloConfigImpl cfg, Configuration hadoopConf) {
@@ -134,20 +130,29 @@ public class ExamplesIT extends AccumuloClusterHarness {
   @Before
   public void getClusterInfo() throws Exception {
     c = getConnector();
-    user = getAdminPrincipal();
+    String user = getAdminPrincipal();
+    String instance = c.getInstance().getInstanceName();
+    String keepers = c.getInstance().getZooKeepers();
     AuthenticationToken token = getAdminToken();
     if (token instanceof KerberosToken) {
-      keytab = getAdminUser().getKeytab().getAbsolutePath();
-      saslEnabled = true;
+      String keytab = getAdminUser().getKeytab().getAbsolutePath();
+      try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(getConnectionFile()))) {
+        writer.write("instance.zookeeper.host=" + keepers + "\n");
+        writer.write("instance.name=" + instance + "\n");
+        writer.write("accumulo.examples.principal=" + user + "\n");
+        writer.write("instance.rpc.sasl.enabled=true\n");
+        writer.write("rpc.sasl.qop=auth\n");
+        writer.write("kerberos.server.primary=accumulo\n");
+        writer.write("accumulo.examples.keytab=" + keytab + "\n");
+
+      }
     } else if (token instanceof PasswordToken) {
-      passwd = new String(((PasswordToken) getAdminToken()).getPassword(), UTF_8);
-      saslEnabled = false;
+      String passwd = new String(((PasswordToken) getAdminToken()).getPassword(), UTF_8);
+      writeConnectionFile(getConnectionFile(), instance, keepers, user, passwd);
     } else {
       Assert.fail("Unknown token type: " + token);
     }
     fs = getCluster().getFileSystem();
-    instance = c.getInstance().getInstanceName();
-    keepers = c.getInstance().getZooKeepers();
     dir = new Path(cluster.getTemporaryPath(), getClass().getName()).toString();
 
     origAuths = c.securityOperations().getUserAuthorizations(user);
@@ -159,6 +164,19 @@ public class ExamplesIT extends AccumuloClusterHarness {
     if (null != origAuths) {
       getConnector().securityOperations().changeUserAuthorizations(getAdminPrincipal(), origAuths);
     }
+  }
+
+  public static void writeConnectionFile(String file, String instance, String keepers, String user, String password) throws IOException {
+    try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(file))) {
+      writer.write("instance.zookeeper.host=" + keepers + "\n");
+      writer.write("instance.name=" + instance + "\n");
+      writer.write("accumulo.examples.principal=" + user + "\n");
+      writer.write("accumulo.examples.password=" + password + "\n");
+    }
+  }
+
+  private String getConnectionFile() {
+    return System.getProperty("user.dir") + "/target/examples.conf";
   }
 
   @Override
@@ -175,12 +193,7 @@ public class ExamplesIT extends AccumuloClusterHarness {
       while (!c.tableOperations().exists("trace"))
         sleepUninterruptibly(500, TimeUnit.MILLISECONDS);
     }
-    String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "-C", "-D", "-c"};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "-C", "-D", "-c"};
-    }
+    String[] args = new String[] {"-c", getConnectionFile(), "--createtable", "--deletetable", "--create"};
     Entry<Integer,String> pair = cluster.getClusterControl().execWithStdout(TracingExample.class, args);
     Assert.assertEquals("Expected return code of zero. STDOUT=" + pair.getValue(), 0, pair.getKey().intValue());
     String result = pair.getValue();
@@ -188,11 +201,7 @@ public class ExamplesIT extends AccumuloClusterHarness {
     Matcher matcher = pattern.matcher(result);
     int count = 0;
     while (matcher.find()) {
-      if (saslEnabled) {
-        args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--traceid", matcher.group(1)};
-      } else {
-        args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--traceid", matcher.group(1)};
-      }
+      args = new String[] {"-c", getConnectionFile(), "--traceid", matcher.group(1)};
       pair = cluster.getClusterControl().execWithStdout(TraceDumpExample.class, args);
       count++;
     }
@@ -239,13 +248,9 @@ public class ExamplesIT extends AccumuloClusterHarness {
     }
     assumeTrue(new File(dirListDirectory).exists());
     // Index a directory listing on /tmp. If this is running against a standalone cluster, we can't guarantee Accumulo source will be there.
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--dirTable", dirTable, "--indexTable", indexTable, "--dataTable",
-          dataTable, "--vis", visibility, "--chunkSize", Integer.toString(10000), dirListDirectory};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--dirTable", dirTable, "--indexTable", indexTable, "--dataTable",
-          dataTable, "--vis", visibility, "--chunkSize", Integer.toString(10000), dirListDirectory};
-    }
+    args = new String[] {"-c", getConnectionFile(), "--dirTable", dirTable, "--indexTable", indexTable, "--dataTable", dataTable, "--vis", visibility,
+        "--chunkSize", Integer.toString(10000), dirListDirectory};
+
     Entry<Integer,String> entry = getClusterControl().execWithStdout(Ingest.class, args);
     assertEquals("Got non-zero return code. Stdout=" + entry.getValue(), 0, entry.getKey().intValue());
 
@@ -262,12 +267,8 @@ public class ExamplesIT extends AccumuloClusterHarness {
       default:
         throw new RuntimeException("Unknown cluster type");
     }
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "--keytab", keytab, "-u", user, "-t", indexTable, "--auths", auths, "--search", "--path",
-          expectedFile};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-p", passwd, "-u", user, "-t", indexTable, "--auths", auths, "--search", "--path", expectedFile};
-    }
+
+    args = new String[] {"-c", getConnectionFile(), "-t", indexTable, "--auths", auths, "--search", "--path", expectedFile};
     entry = getClusterControl().execWithStdout(QueryUtil.class, args);
     if (ClusterType.MINI == getClusterType()) {
       MiniAccumuloClusterImpl impl = (MiniAccumuloClusterImpl) cluster;
@@ -339,37 +340,22 @@ public class ExamplesIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     c.tableOperations().create(tableName);
     c.tableOperations().setProperty(tableName, Property.TABLE_BLOOM_ENABLED.getKey(), "true");
-    String[] args;
-    if (saslEnabled) {
-      args = new String[] {"--seed", "7", "-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--num", "100000", "--min", "0", "--max",
-          "1000000000", "--size", "50", "--batchMemory", "2M", "--batchLatency", "60s", "--batchThreads", "3", "-t", tableName};
-    } else {
-      args = new String[] {"--seed", "7", "-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--num", "100000", "--min", "0", "--max", "1000000000",
-          "--size", "50", "--batchMemory", "2M", "--batchLatency", "60s", "--batchThreads", "3", "-t", tableName};
-    }
+    String[] args = new String[] {"--seed", "7", "-c", getConnectionFile(), "--num", "100000", "--min", "0", "--max", "1000000000", "--size", "50",
+        "--batchMemory", "2M", "--batchLatency", "60", "--batchThreads", "3", "-t", tableName};
+
     goodExec(RandomBatchWriter.class, args);
     c.tableOperations().flush(tableName, null, null, true);
     long diff = 0, diff2 = 0;
     // try the speed test a couple times in case the system is loaded with other tests
     for (int i = 0; i < 2; i++) {
       long now = System.currentTimeMillis();
-      if (saslEnabled) {
-        args = new String[] {"--seed", "7", "-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--num", "10000", "--min", "0", "--max",
-            "1000000000", "--size", "50", "--scanThreads", "4", "-t", tableName};
-      } else {
-        args = new String[] {"--seed", "7", "-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--num", "10000", "--min", "0", "--max", "1000000000",
-            "--size", "50", "--scanThreads", "4", "-t", tableName};
-      }
+      args = new String[] {"--seed", "7", "-c", getConnectionFile(), "--num", "10000", "--min", "0", "--max", "1000000000", "--size", "50", "--scanThreads",
+          "4", "-t", tableName};
       goodExec(RandomBatchScanner.class, args);
       diff = System.currentTimeMillis() - now;
       now = System.currentTimeMillis();
-      if (saslEnabled) {
-        args = new String[] {"--seed", "8", "-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--num", "10000", "--min", "0", "--max",
-            "1000000000", "--size", "50", "--scanThreads", "4", "-t", tableName};
-      } else {
-        args = new String[] {"--seed", "8", "-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--num", "10000", "--min", "0", "--max", "1000000000",
-            "--size", "50", "--scanThreads", "4", "-t", tableName};
-      }
+      args = new String[] {"--seed", "8", "-c", getConnectionFile(), "--num", "10000", "--min", "0", "--max", "1000000000", "--size", "50", "--scanThreads",
+          "4", "-t", tableName};
       int retCode = getClusterControl().exec(RandomBatchScanner.class, args);
       assertEquals(1, retCode);
       diff2 = System.currentTimeMillis() - now;
@@ -401,22 +387,11 @@ public class ExamplesIT extends AccumuloClusterHarness {
     }
     assertTrue(thisFile);
 
-    String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "--shardTable", shard, "--doc2Term", index, "-u", user, "--keytab", keytab};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "--shardTable", shard, "--doc2Term", index, "-u", getAdminPrincipal(), "-p", passwd};
-    }
+    String[] args = new String[] {"-c", getConnectionFile(), "--shardTable", shard, "--doc2Term", index};
+
     // create a reverse index
     goodExec(Reverse.class, args);
-
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "--shardTable", shard, "--doc2Term", index, "-u", user, "--keytab", keytab, "--terms", "5",
-          "--count", "1000"};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "--shardTable", shard, "--doc2Term", index, "-u", user, "-p", passwd, "--terms", "5", "--count",
-          "1000"};
-    }
+    args = new String[] {"-c", getConnectionFile(), "--shardTable", shard, "--doc2Term", index, "--terms", "5", "--count", "1000"};
     // run some queries
     goodExec(ContinuousQuery.class, args);
   }
@@ -430,11 +405,7 @@ public class ExamplesIT extends AccumuloClusterHarness {
     opts.rows = 1;
     opts.cols = 1000;
     opts.setTableName(tableName);
-    if (saslEnabled) {
-      opts.updateKerberosCredentials(cluster.getClientConfig());
-    } else {
-      opts.setPrincipal(getAdminPrincipal());
-    }
+    opts.setPrincipal(getAdminPrincipal());
     try {
       TestIngest.ingest(c, opts, bwOpts);
     } catch (MutationsRejectedException ex) {
@@ -454,14 +425,7 @@ public class ExamplesIT extends AccumuloClusterHarness {
     }
     goodExec(GenerateTestData.class, "--start-row", "0", "--count", "10000", "--output", dir + "/tmp/input/data");
 
-    List<String> commonArgs = new ArrayList<>(Arrays.asList(new String[] {"-i", instance, "-z", keepers, "-u", user, "--table", tableName}));
-    if (saslEnabled) {
-      commonArgs.add("--keytab");
-      commonArgs.add(keytab);
-    } else {
-      commonArgs.add("-p");
-      commonArgs.add(passwd);
-    }
+    List<String> commonArgs = new ArrayList<>(Arrays.asList(new String[] {"-c", getConnectionFile(), "--table", tableName}));
 
     List<String> args = new ArrayList<>(commonArgs);
     goodExec(SetupTable.class, args.toArray(new String[0]));
@@ -480,41 +444,22 @@ public class ExamplesIT extends AccumuloClusterHarness {
     // TODO Figure out a way to run M/R with Kerberos
     assumeTrue(getAdminToken() instanceof PasswordToken);
     String tableName = getUniqueNames(1)[0];
-    String[] args;
-    if (saslEnabled) {
-      args = new String[] {"--count", (1000 * 1000) + "", "-nk", "10", "-xk", "10", "-nv", "10", "-xv", "10", "-t", tableName, "-i", instance, "-z", keepers,
-          "-u", user, "--keytab", keytab, "--splits", "4"};
-    } else {
-      args = new String[] {"--count", (1000 * 1000) + "", "-nk", "10", "-xk", "10", "-nv", "10", "-xv", "10", "-t", tableName, "-i", instance, "-z", keepers,
-          "-u", user, "-p", passwd, "--splits", "4"};
-    }
+    String[] args = new String[] {"--count", (1000 * 1000) + "", "-nk", "10", "-xk", "10", "-nv", "10", "-xv", "10", "-t", tableName, "-c", getConnectionFile(),
+        "--splits", "4"};
     goodExec(TeraSortIngest.class, args);
     Path output = new Path(dir, "tmp/nines");
     if (fs.exists(output)) {
       fs.delete(output, true);
     }
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "-t", tableName, "--rowRegex", ".*999.*", "--output",
-          output.toString()};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "-t", tableName, "--rowRegex", ".*999.*", "--output", output.toString()};
-    }
+    args = new String[] {"-c", getConnectionFile(), "-t", tableName, "--rowRegex", ".*999.*", "--output", output.toString()};
     goodExec(RegexExample.class, args);
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "-t", tableName, "--column", "c:"};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "-t", tableName, "--column", "c:"};
-    }
+    args = new String[] {"-c", getConnectionFile(), "-t", tableName, "--column", "c:"};
     goodExec(RowHash.class, args);
     output = new Path(dir, "tmp/tableFile");
     if (fs.exists(output)) {
       fs.delete(output, true);
     }
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "-t", tableName, "--output", output.toString()};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "-t", tableName, "--output", output.toString()};
-    }
+    args = new String[] {"-c", getConnectionFile(), "-t", tableName, "--output", output.toString()};
     goodExec(TableToFile.class, args);
   }
 
@@ -535,11 +480,7 @@ public class ExamplesIT extends AccumuloClusterHarness {
     }
     fs.copyFromLocalFile(readme, new Path(dir + "/tmp/wc/README.md"));
     String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-u", user, "--keytab", keytab, "-z", keepers, "--input", dir + "/tmp/wc", "-t", tableName};
-    } else {
-      args = new String[] {"-i", instance, "-u", user, "-p", passwd, "-z", keepers, "--input", dir + "/tmp/wc", "-t", tableName};
-    }
+    args = new String[] {"-c", getConnectionFile(), "--input", dir + "/tmp/wc", "-t", tableName};
     goodExec(WordCount.class, args);
   }
 
@@ -547,11 +488,7 @@ public class ExamplesIT extends AccumuloClusterHarness {
   public void testInsertWithBatchWriterAndReadData() throws Exception {
     String tableName = getUniqueNames(1)[0];
     String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "-t", tableName};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "-t", tableName};
-    }
+    args = new String[] {"-c", getConnectionFile(), "-t", tableName};
     goodExec(InsertWithBatchWriter.class, args);
     goodExec(ReadData.class, args);
   }
@@ -559,33 +496,21 @@ public class ExamplesIT extends AccumuloClusterHarness {
   @Test
   public void testIsolatedScansWithInterference() throws Exception {
     String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "-t", getUniqueNames(1)[0], "--iterations", "100000", "--isolated"};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "-t", getUniqueNames(1)[0], "--iterations", "100000", "--isolated"};
-    }
+    args = new String[] {"-c", getConnectionFile(), "-t", getUniqueNames(1)[0], "--iterations", "100000", "--isolated"};
     goodExec(InterferenceTest.class, args);
   }
 
   @Test
   public void testScansWithInterference() throws Exception {
     String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "-t", getUniqueNames(1)[0], "--iterations", "100000"};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "-t", getUniqueNames(1)[0], "--iterations", "100000"};
-    }
+    args = new String[] {"-c", getConnectionFile(), "-t", getUniqueNames(1)[0], "--iterations", "100000"};
     goodExec(InterferenceTest.class, args);
   }
 
   @Test
   public void testRowOperations() throws Exception {
     String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd};
-    }
+    args = new String[] {"-c", getConnectionFile()};
     goodExec(RowOperations.class, args);
   }
 
@@ -594,13 +519,8 @@ public class ExamplesIT extends AccumuloClusterHarness {
     String tableName = getUniqueNames(1)[0];
     c.tableOperations().create(tableName);
     String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "-t", tableName, "--start", "0", "--num", "100000", "--size", "50",
-          "--batchMemory", "10000000", "--batchLatency", "1000", "--batchThreads", "4", "--vis", visibility};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "-t", tableName, "--start", "0", "--num", "100000", "--size", "50",
-          "--batchMemory", "10000000", "--batchLatency", "1000", "--batchThreads", "4", "--vis", visibility};
-    }
+    args = new String[] {"-c", getConnectionFile(), "-t", tableName, "--start", "0", "--num", "100000", "--size", "50", "--batchMemory", "10000000",
+        "--batchLatency", "1000", "--batchThreads", "4", "--vis", visibility};
     goodExec(SequentialBatchWriter.class, args);
 
   }
@@ -609,18 +529,9 @@ public class ExamplesIT extends AccumuloClusterHarness {
   public void testReadWriteAndDelete() throws Exception {
     String tableName = getUniqueNames(1)[0];
     String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--auths", auths, "--table", tableName, "--createtable", "-c",
-          "--debug"};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--auths", auths, "--table", tableName, "--createtable", "-c", "--debug"};
-    }
+    args = new String[] {"-c", getConnectionFile(), "--auths", auths, "--table", tableName, "--createtable", "--create"};
     goodExec(ReadWriteExample.class, args);
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--auths", auths, "--table", tableName, "-d", "--debug"};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--auths", auths, "--table", tableName, "-d", "--debug"};
-    }
+    args = new String[] {"-c", getConnectionFile(), "--auths", auths, "--table", tableName, "--delete"};
     goodExec(ReadWriteExample.class, args);
 
   }
@@ -629,30 +540,15 @@ public class ExamplesIT extends AccumuloClusterHarness {
   public void testRandomBatchesAndFlush() throws Exception {
     String tableName = getUniqueNames(1)[0];
     c.tableOperations().create(tableName);
-    String[] args;
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--table", tableName, "--num", "100000", "--min", "0", "--max",
-          "100000", "--size", "100", "--batchMemory", "1000000", "--batchLatency", "1000", "--batchThreads", "4", "--vis", visibility};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--table", tableName, "--num", "100000", "--min", "0", "--max", "100000",
-          "--size", "100", "--batchMemory", "1000000", "--batchLatency", "1000", "--batchThreads", "4", "--vis", visibility};
-    }
+    String[] args = new String[] {"-c", getConnectionFile(), "--table", tableName, "--num", "100000", "--min", "0", "--max", "100000", "--size", "100",
+        "--batchMemory", "1000000", "--batchLatency", "1000", "--batchThreads", "4", "--vis", visibility};
     goodExec(RandomBatchWriter.class, args);
 
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--table", tableName, "--num", "10000", "--min", "0", "--max",
-          "100000", "--size", "100", "--scanThreads", "4", "--auths", auths};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--table", tableName, "--num", "10000", "--min", "0", "--max", "100000",
-          "--size", "100", "--scanThreads", "4", "--auths", auths};
-    }
+    args = new String[] {"-c", getConnectionFile(), "--table", tableName, "--num", "10000", "--min", "0", "--max", "100000", "--size", "100", "--scanThreads",
+        "4", "--auths", auths};
     goodExec(RandomBatchScanner.class, args);
 
-    if (saslEnabled) {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "--keytab", keytab, "--table", tableName};
-    } else {
-      args = new String[] {"-i", instance, "-z", keepers, "-u", user, "-p", passwd, "--table", tableName};
-    }
+    args = new String[] {"-c", getConnectionFile(), "--table", tableName};
     goodExec(Flush.class, args);
   }
 

--- a/src/test/java/org/apache/accumulo/examples/dirlist/CountIT.java
+++ b/src/test/java/org/apache/accumulo/examples/dirlist/CountIT.java
@@ -22,8 +22,6 @@ import static org.junit.Assert.assertFalse;
 import java.util.ArrayList;
 import java.util.Map.Entry;
 
-import org.apache.accumulo.core.cli.BatchWriterOpts;
-import org.apache.accumulo.core.cli.ScannerOpts;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.BatchWriterConfig;
 import org.apache.accumulo.core.client.Connector;
@@ -33,10 +31,8 @@ import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.core.util.Pair;
-import org.apache.accumulo.examples.dirlist.FileCount;
-import org.apache.accumulo.examples.dirlist.FileCount.Opts;
-import org.apache.accumulo.examples.dirlist.Ingest;
-import org.apache.accumulo.examples.dirlist.QueryUtil;
+import org.apache.accumulo.examples.cli.BatchWriterOpts;
+import org.apache.accumulo.examples.cli.ScannerOpts;
 import org.apache.accumulo.test.functional.ConfigurableMacBase;
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
@@ -73,15 +69,9 @@ public class CountIT extends ConfigurableMacBase {
     scanner.fetchColumn(new Text("dir"), new Text("counts"));
     assertFalse(scanner.iterator().hasNext());
 
-    Opts opts = new Opts();
     ScannerOpts scanOpts = new ScannerOpts();
     BatchWriterOpts bwOpts = new BatchWriterOpts();
-    opts.instance = conn.getInstance().getInstanceName();
-    opts.zookeepers = conn.getInstance().getZooKeepers();
-    opts.setTableName(tableName);
-    opts.setPrincipal(conn.whoami());
-    opts.setPassword(new Opts.Password(ROOT_PASSWORD));
-    FileCount fc = new FileCount(opts, scanOpts, bwOpts);
+    FileCount fc = new FileCount(conn, tableName, Authorizations.EMPTY, new ColumnVisibility(), scanOpts, bwOpts);
     fc.run();
 
     ArrayList<Pair<String,String>> expected = new ArrayList<>();

--- a/src/test/java/org/apache/accumulo/examples/filedata/ChunkCombinerTest.java
+++ b/src/test/java/org/apache/accumulo/examples/filedata/ChunkCombinerTest.java
@@ -26,8 +26,6 @@ import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import junit.framework.TestCase;
-
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.PartialKey;
@@ -35,6 +33,8 @@ import org.apache.accumulo.core.data.Range;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.iterators.IteratorEnvironment;
 import org.apache.accumulo.core.iterators.SortedKeyValueIterator;
+
+import junit.framework.TestCase;
 
 public class ChunkCombinerTest extends TestCase {
 

--- a/src/test/java/org/apache/accumulo/examples/filedata/ChunkInputFormatIT.java
+++ b/src/test/java/org/apache/accumulo/examples/filedata/ChunkInputFormatIT.java
@@ -37,7 +37,6 @@ import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.accumulo.core.security.ColumnVisibility;
-import org.apache.accumulo.examples.filedata.ChunkInputFormat;
 import org.apache.accumulo.harness.AccumuloClusterHarness;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;

--- a/src/test/java/org/apache/accumulo/examples/filedata/KeyUtilTest.java
+++ b/src/test/java/org/apache/accumulo/examples/filedata/KeyUtilTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.accumulo.examples.filedata;
 
-import junit.framework.TestCase;
-
 import org.apache.hadoop.io.Text;
+
+import junit.framework.TestCase;
 
 public class KeyUtilTest extends TestCase {
   public static void checkSeps(String... s) {


### PR DESCRIPTION
… code.

In the processing of doing this I copied and simplified code from Accumulo.
Also started using a properties file in all examples for Accumulo connection
info.  This should make it easier to run all examples.  No longer need to
change instance, zookeepers, user and password when running examples.