### PR TITLE
ACCUMULO-4516: TeraSortIngest splits argument is ignored if less that 10

### DIFF
--- a/src/main/java/org/apache/accumulo/examples/mapreduce/TeraSortIngest.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/TeraSortIngest.java
@@ -390,7 +390,7 @@ public class TeraSortIngest extends Configured implements Tool {
     conf.setInt("cloudgen.maxvaluelength", opts.maxValueLength);
     conf.set("cloudgen.tablename", opts.getTableName());
 
-    if (args.length > 10)
+    if (opts.splits != 0)
       conf.setInt(NUMSPLITS, opts.splits);
 
     job.waitForCompletion(true);


### PR DESCRIPTION
ACCUMULO-4516: TeraSortIngest splits argument is ignored if less that 10 arguments are provided.

Modified TeraSortIngest.java to remove arg length check as a condition
for setting the number of splits.  Instead check to see if the splits option
is non-zero and if so, set the number of splits.