### PR TITLE
Added Missing Licenses

### DIFF
--- a/spark/run.sh
+++ b/spark/run.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 if [[ -z "$1" || -z "$2" ]]; then
   echo "Usage: ./run.sh [bulk|batch] /path/to/accumulo-client.properties"
   exit 1

--- a/spark/src/main/java/org/apache/accumulo/spark/CopyPlus5K.java
+++ b/spark/src/main/java/org/apache/accumulo/spark/CopyPlus5K.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.accumulo.spark;
 
 import java.util.Arrays;


### PR DESCRIPTION
I noticed the Travis Ci build was failing due to two files missing a license. So I went ahead and added them so it would build, assuming those files are needed.