### PR TITLE
Allows HDFS to correctly navigate to correct location of split file.

### DIFF
--- a/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/BulkIngestExample.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/BulkIngestExample.java
@@ -43,8 +43,8 @@ import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
  * files containing tab separated key value pairs on each line.
  */
 public class BulkIngestExample {
-  static String workDir = "tmp/bulkWork";
-  static String inputDir = "bulk";
+  static String workDir = "./tmp/bulkWork";
+  static String inputDir = "./bulk";
 
   public static class MapClass extends Mapper<LongWritable,Text,Text,Text> {
     private Text outputKey = new Text();


### PR DESCRIPTION
In order to use the new hdfs caching code in the fix for Accumulo-1052 the workDir variable in the BulkImportTest class needs to be defined explicitly as relative path to working directory or hdfs assumes later on in the map reduce job that it the fragment link is located in the 'users' home linux directory which is not where the test is executing.  Here is some debug output to verify the link creation.

[main} INFO  org.apache.hadoop.mapreduce.lib.input.FileInputFormat  - Total input files to process : 1
[main} INFO  org.apache.hadoop.mapreduce.JobSubmitter  - number of splits:1
[main} INFO  org.apache.hadoop.mapreduce.JobSubmitter  - Submitting tokens for job: job_local936074918_0001
[main} INFO  org.apache.hadoop.mapreduce.JobSubmitter  - Executing with tokens: []
[main} INFO  org.apache.hadoop.mapred.LocalDistributedCacheManager  - Creating symlink: /tmp/hadoop-jzeiberg/mapred/local/1559593685834/splits.txt <- /home/jzeiberg/github/my_accumulo_examples/org.apache.accumulo.hadoop.mapreduce.partition.RangePartitioner.cutFile
[main} INFO  org.apache.hadoop.mapred.LocalDistributedCacheManager  - Localized file:/home/jzeiberg/github/my_accumulo_examples/tmp/bulkWork/splits.txt as file:/tmp/hadoop-jzeiberg/mapred/local/1559593685834/splits.txt

The link to the splits.txt file that is created is called: org.apache.accumulo.hadoop.mapreduce.partition.RangePartitioner.cutFile.  That link actually gets used in RangePartitioner.getCutPoints now.

