### PR TITLE
Bring the hadoop version in line with Accumulo 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <description>Example code and corresponding documentation for using Apache Accumulo</description>
   <properties>
     <accumulo.version>2.0.0-SNAPSHOT</accumulo.version>
-    <hadoop.version>3.1.1</hadoop.version>
+    <hadoop.version>3.2.0</hadoop.version>
     <slf4j.version>1.7.21</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
Working on getting BulkIngestExample to work perfectly which it is not now but this upgrade to Hadoop 3.2.0 needs to be done because that is the version Accumulo is running on in trunk now.