### PR TITLE
Correctly set/delete paths in BulkIngestExample and SetupTable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
   <name>Apache Accumulo Examples</name>
   <description>Example code and corresponding documentation for using Apache Accumulo</description>
   <properties>
-    <accumulo.version>2.0.0-SNAPSHOT</accumulo.version>
-    <hadoop.version>3.1.1</hadoop.version>
+    <accumulo.version>2.1.1</accumulo.version>
+    <hadoop.version>3.2.0</hadoop.version>
     <slf4j.version>1.7.21</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/org/apache/accumulo/examples/client/SequentialBatchWriter.java
+++ b/src/main/java/org/apache/accumulo/examples/client/SequentialBatchWriter.java
@@ -16,7 +16,8 @@
  */
 package org.apache.accumulo.examples.client;
 
-import com.beust.jcommander.Parameter;
+import java.util.Random;
+
 import org.apache.accumulo.core.client.*;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -24,7 +25,7 @@ import org.apache.accumulo.examples.cli.ClientOpts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Random;
+import com.beust.jcommander.Parameter;
 
 /**
  * Simple example for writing random data in sequential order to Accumulo.

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/SetupTable.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/SetupTable.java
@@ -39,6 +39,11 @@ public class SetupTable {
   public static void main(String[] args) throws Exception {
     ClientOpts opts = new ClientOpts();
     opts.parseArgs(SetupTable.class.getName(), args);
+    FileSystem fs = FileSystem.get(new Configuration());
+
+    Path inputPath = new Path("bulk");
+    if (fs.exists(inputPath))
+      fs.delete(inputPath, true);
 
     try (AccumuloClient client = Accumulo.newClient().from(opts.getClientPropsPath()).build()) {
       try {
@@ -54,7 +59,6 @@ public class SetupTable {
       }
       client.tableOperations().addSplits(tableName, intialPartitions);
 
-      FileSystem fs = FileSystem.get(new Configuration());
       try (PrintStream out = new PrintStream(
           new BufferedOutputStream(fs.create(new Path(outputFile))))) {
         // create some data in outputFile


### PR DESCRIPTION
This gets the map reduce steps working correctly in the test.  Since directories  were not being removed the `BulkImportExample` would fail sometimes because the input directory would already exist.  The work directory would get put in the project directory and cause `./bin/build` to fail as well as `mvn clean install -DskipTests=true` to fail.  

There is more work to do here to get this error to go away.

```java
Exception in thread "main" org.apache.accumulo.core.client.AccumuloException: file:/tmp/bulkWork/files: java.io.IOException: file:/tmp/bulkWork/files is not in a volume configured for Accumulo
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.doFateOperation(TableOperationsImpl.java:385)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.doFateOperation(TableOperationsImpl.java:342)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.doTableFateOperation(TableOperationsImpl.java:1599)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.importDirectory(TableOperationsImpl.java:1207)
	at org.apache.accumulo.examples.mapreduce.bulk.BulkIngestExample.main(BulkIngestExample.java:146)
Caused by: ThriftTableOperationException(tableId:2, tableName:null, op:BULK_IMPORT, type:BULK_BAD_INPUT_DIRECTORY, description:file:/tmp/bulkWork/files: java.io.IOException: file:/tmp/bulkWork/files is not in a volume configured for Accumulo)
	at org.apache.accumulo.core.master.thrift.FateService$waitForFateOperation_result$waitForFateOperation_resultStandardScheme.read(FateService.java:4730)
	at org.apache.accumulo.core.master.thrift.FateService$waitForFateOperation_result$waitForFateOperation_resultStandardScheme.read(FateService.java:4699)
	at org.apache.accumulo.core.master.thrift.FateService$waitForFateOperation_result.read(FateService.java:4625)
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:88)
	at org.apache.accumulo.core.master.thrift.FateService$Client.recv_waitForFateOperation(FateService.java:156)
	at org.apache.accumulo.core.master.thrift.FateService$Client.waitForFateOperation(FateService.java:141)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.waitForFateOperation(TableOperationsImpl.java:292)
	at org.apache.accumulo.core.clientImpl.TableOperationsImpl.doFateOperation(TableOperationsImpl.java:358)
```