### PR TITLE
Make sure to copy accumulo-examples.jar 

### DIFF
--- a/docs/bulkIngest.md
+++ b/docs/bulkIngest.md
@@ -24,9 +24,9 @@ This tutorial uses the following Java classes.
  * [BulkIngestExample.java] - ingest the data using map reduce
  * [VerifyIngest.java] - checks that the data was ingested
  
-Remember to copy the accumulo-examples-\*.jar to Accumulo's 'lib/ext' directory.
+Remember to copy the accumulo-examples\*.jar to Accumulo's 'lib/ext' directory.
 
-    $ cp target/accumulo-examples-*.jar /path/accumulo/lib/ext
+    $ cp target/accumulo-examples*.jar /path/accumulo/lib/ext
 
 The following commands show how to run this example. This example creates a
 table called test_bulk which has two initial split points. Then 1000 rows of


### PR DESCRIPTION
as well as accumulo-examples-shaded.jar


The command in the old readme would only copy the shaded jar because of the hyphen in front of the asterisk.

```bash
jzeiberg@dragonfly:~/github/my_accumulo_examples$ ls target/accumulo-examples-*.jar
target/accumulo-examples-shaded.jar
jzeiberg@dragonfly:~/github/my_accumulo_examples$ ls target/accumulo-examples*.jar
target/accumulo-examples.jar  target/accumulo-examples-shaded.jar
```