### PR TITLE
Update BulkIngest example to work with 2.0.x

### DIFF
--- a/docs/bulkIngest.md
+++ b/docs/bulkIngest.md
@@ -16,18 +16,14 @@ limitations under the License.
 -->
 # Apache Accumulo Bulk Ingest Example
 
-This is an example of how to bulk ingest data into Accumulo using map reduce.
+This is an example of how to bulk ingest data into Accumulo using mapReduce.
 
 This tutorial uses the following Java classes.
 
- * [SetupTable.java] - creates the table and some data to ingest
- * [BulkIngestExample.java] - ingest the data using map reduce
+ * [SetupTable.java] - creates the table, 'test_bulk', and sets two split points.
+ * [BulkIngestExample.java] - creates some data to ingest and then ingests the data using mapReduce
  * [VerifyIngest.java] - checks that the data was ingested
  
-Remember to copy the accumulo-examples\*.jar to Accumulo's 'lib/ext' directory.
-
-    $ cp target/accumulo-examples*.jar /path/accumulo/lib/ext
-
 The following commands show how to run this example. This example creates a
 table called test_bulk which has two initial split points. Then 1000 rows of
 test data are created in HDFS. After that the 1000 rows are ingested into

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/SetupTable.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/bulk/SetupTable.java
@@ -16,25 +16,20 @@
  */
 package org.apache.accumulo.examples.mapreduce.bulk;
 
-import java.io.BufferedOutputStream;
-import java.io.PrintStream;
 import java.util.TreeSet;
 
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.examples.cli.ClientOpts;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Text;
 
-public class SetupTable {
+public final class SetupTable {
 
-  static String[] splits = {"row_00000333", "row_00000666"};
-  static String tableName = "test_bulk";
-  static int numRows = 1000;
-  static String outputFile = "bulk/test_1.txt";
+  static final String[] splits = {"row_00000333", "row_00000666"};
+  static final String tableName = "test_bulk";
+
+  private SetupTable() {}
 
   public static void main(String[] args) throws Exception {
     ClientOpts opts = new ClientOpts();
@@ -48,20 +43,11 @@ public class SetupTable {
       }
 
       // create a table with initial partitions
-      TreeSet<Text> intialPartitions = new TreeSet<>();
+      TreeSet<Text> initialPartitions = new TreeSet<>();
       for (String split : splits) {
-        intialPartitions.add(new Text(split));
+        initialPartitions.add(new Text(split));
       }
-      client.tableOperations().addSplits(tableName, intialPartitions);
-
-      FileSystem fs = FileSystem.get(new Configuration());
-      try (PrintStream out = new PrintStream(
-          new BufferedOutputStream(fs.create(new Path(outputFile))))) {
-        // create some data in outputFile
-        for (int i = 0; i < numRows; i++) {
-          out.println(String.format("row_%010d\tvalue_%010d", i, i));
-        }
-      }
+      client.tableOperations().addSplits(tableName, initialPartitions);
     }
   }
 }


### PR DESCRIPTION
Update the bulkIngest example to work correctly with Accumulo 2.0.x. Minor updates made to the documentation. The classes were refactored so the example will work correctly with 2.0 changes. Generation of test data was moved from SetupTable to BulkIngestExample (as in 1.10.x version). Prior to change, necessary data was not correctly being written to HDFS thereby preventing the BulkIngestExample class from finding information needed to generate the data.