### PR TITLE
Update main branch to work against Accumulo 2.1.x.

### DIFF
--- a/bin/runex
+++ b/bin/runex
@@ -40,4 +40,5 @@ fi
 # Build shaded jar (if not built already)
 "$ex_home"/bin/build
 
-java -cp $EXAMPLES_JAR_PATH -Dlog4j.configuration="file:$EXAMPLES_LOG4J" "org.apache.accumulo.examples.$1" ${*:2}
+java -cp $EXAMPLES_JAR_PATH -Dlog4j.configurationFile="$EXAMPLES_LOG4J" "org.apache.accumulo.examples.$1" ${*:2}
+

--- a/conf/log4j.properties.example
+++ b/conf/log4j.properties.example
@@ -13,15 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-log4j.rootLogger=INFO, CA
-log4j.appender.CA=org.apache.log4j.ConsoleAppender
-log4j.appender.CA.layout=org.apache.log4j.PatternLayout
-log4j.appender.CA.layout.ConversionPattern=%d{ISO8601} [%c{3}] %-5p: %m%n
+status = info
+dest = err
+name = AccumuloExampleConfig
 
-log4j.logger.org.apache.accumulo=INFO
-log4j.logger.org.apache.accumulo.examples=TRACE
-log4j.logger.org.apache.curator=ERROR
-log4j.logger.org.apache.hadoop=WARN
-log4j.logger.org.apache.hadoop.mapreduce=ERROR
-log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
-log4j.logger.org.apache.zookeeper=ERROR
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.target = SYSTEM_OUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+
+logger.zookeeper.name = org.apache.zookeeper
+logger.zookeeper.level = error
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = STDOUT

--- a/pom.xml
+++ b/pom.xml
@@ -31,10 +31,10 @@
     <accumulo.version>2.0.0</accumulo.version>
     <eclipseFormatterStyle>contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <hadoop.version>3.2.1</hadoop.version>
+    <log4j.version>2.14.0</log4j.version>
     <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <slf4j.version>1.7.30</slf4j.version>
     <zookeeper.version>3.4.14</zookeeper.version>
   </properties>
   <dependencyManagement>
@@ -97,15 +97,19 @@
       <version>${zookeeper.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>${slf4j.version}</version>
-      <scope>runtime</scope>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>
@@ -305,6 +309,7 @@
                 </goals>
                 <phase>package</phase>
                 <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
                   <finalName>${project.artifactId}-shaded</finalName>
                   <shadedArtifactAttached>true</shadedArtifactAttached>
                   <shadedClassifierName>shaded</shadedClassifierName>
@@ -320,6 +325,12 @@
                         <exclude>META-INF/*.SF</exclude>
                         <exclude>META-INF/*.DSA</exclude>
                         <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>**/Log4j2Plugins.dat</exclude>
                       </excludes>
                     </filter>
                   </filters>


### PR DESCRIPTION
Update pom.xml, log4j.properties.example, and bin/runex files to allow accumulo-examples to run against the 2.1.x version of Accumulo.