### PR TITLE
Fix logging bugs and update plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 /.idea
 /examples.conf
 /conf/env.sh
-/conf/log4j.properties

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Follow the steps below to run the Accumulo examples:
         cp conf/env.sh.example conf/env.sh
         vim conf/env.sh
 
-3. Build the examples repo and copy the examples jar to Accumulo's `lib/ext` directory:
+3. Build the examples repo and copy the examples jar to Accumulo's `lib/` directory to get on its
+   class path:
 
         ./bin/build
-        cp target/accumulo-examples.jar /path/to/accumulo/lib/ext/
+        cp target/accumulo-examples.jar /path/to/accumulo/lib/
 
 4. Each Accumulo example has its own documentation and instructions for running the example which
    are linked to below.

--- a/bin/runex
+++ b/bin/runex
@@ -40,5 +40,6 @@ fi
 # Build shaded jar (if not built already)
 "$ex_home"/bin/build
 
-java -cp $EXAMPLES_JAR_PATH -Dlog4j.configurationFile="$EXAMPLES_LOG4J" "org.apache.accumulo.examples.$1" ${*:2}
+export CLASSPATH="$EXAMPLES_JAR_PATH:$ex_home/conf:$ACCUMULO_HOME/lib/*:$CLASSPATH"
+java "org.apache.accumulo.examples.$1" ${*:2}
 

--- a/conf/env.sh.example
+++ b/conf/env.sh.example
@@ -26,21 +26,13 @@ export ACCUMULO_CLIENT_PROPS="$ACCUMULO_HOME/conf/accumulo-client.properties"
 # Configuration
 # =============
 conf_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-export EXAMPLES_LOG4J="${conf_dir}/log4j.properties"
-if [ ! -f "$EXAMPLES_LOG4J" ]; then
-  export EXAMPLES_LOG4J="${conf_dir}/log4j.properties.example"
-  if [ ! -f "$EXAMPLES_LOG4J" ]; then
-    echo "Could not find logj4.properties or log4j.properties.example in $conf_dir"
-    exit 1
-  fi
-fi
 
 # Shaded jar
 # ===============
 # Versions set below will be what is included in the shaded jar
 export ACCUMULO_VERSION="`$ACCUMULO_HOME/bin/accumulo version`"
 export HADOOP_VERSION="`hadoop version | head -n1 | awk '{print $2}'`"
-export ZOOKEEPER_VERSION=3.5.9
+export ZOOKEEPER_VERSION=3.7.0
 # Path to shaded test jar
 ex_home=$( cd "$( dirname "$conf_dir" )" && pwd )
 export EXAMPLES_JAR_PATH="${ex_home}/target/accumulo-examples-shaded.jar"

--- a/conf/log4j2.properties
+++ b/conf/log4j2.properties
@@ -16,15 +16,17 @@
 status = info
 dest = err
 name = AccumuloExampleConfig
+monitorInterval = 30
 
 appender.console.type = Console
-appender.console.name = STDOUT
-appender.console.target = SYSTEM_OUT
+appender.console.name = STDERR
+appender.console.target = SYSTEM_ERR
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ISO8601} [%-8c{2}] %-5p: %m%n
+appender.console.layout.pattern = %style{%d{ISO8601}}{dim,cyan} %style{[}{red}%style{%-8c{2}}{dim,blue}%style{]}{red} %highlight{%-5p}%style{:}{red} %m%n
 
 logger.zookeeper.name = org.apache.zookeeper
 logger.zookeeper.level = error
 
 rootLogger.level = info
-rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.ref = STDERR
+

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <minimalMavenBuildVersion>3.5.0</minimalMavenBuildVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2020-12-17T22:06:50Z</project.build.outputTimestamp>
-    <zookeeper.version>3.5.9</zookeeper.version>
+    <zookeeper.version>3.7.0</zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -74,10 +74,6 @@
     <dependency>
       <groupId>org.apache.accumulo</groupId>
       <artifactId>accumulo-hadoop-mapreduce</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.accumulo</groupId>
-      <artifactId>accumulo-tracer</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -155,7 +151,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -185,7 +180,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>9.1</version>
+            <version>9.3</version>
           </dependency>
         </dependencies>
         <executions>
@@ -203,7 +198,7 @@
         <version>1.6.2</version>
         <configuration>
           <removeUnused>true</removeUnused>
-          <groups>java.,javax.,org.,com.</groups>
+          <groups>java.,javax.,jakarta.,org.,com.</groups>
         </configuration>
         <executions>
           <execution>
@@ -238,15 +233,11 @@
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
         <artifactId>formatter-maven-plugin</artifactId>
-        <version>2.17.1</version>
+        <version>2.18.0</version>
         <configuration>
-          <compilerCompliance>${maven.compiler.source}</compilerCompliance>
-          <compilerSource>${maven.compiler.source}</compilerSource>
-          <compilerTargetPlatform>${maven.compiler.target}</compilerTargetPlatform>
           <configFile>${eclipseFormatterStyle}</configFile>
           <lineEnding>LF</lineEnding>
           <overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
-          <removeTrailingWhitespace>true</removeTrailingWhitespace>
           <skipCssFormatting>true</skipCssFormatting>
           <skipHtmlFormatting>true</skipHtmlFormatting>
           <skipJsFormatting>true</skipJsFormatting>
@@ -290,7 +281,7 @@
                       <exclude>org.apache.logging.log4j:log4j-api:jar:</exclude>
                       <exclude>org.apache.logging.log4j:log4j-1.2-api:jar:</exclude>
                       <exclude>org.apache.logging.log4j:log4j-slf4j-impl:jar:</exclude>
-                      <exclude>javax.activation:javax.activation-api:jar:</exclude>
+                      <exclude>jakarta.activation:jakarta.activation-api:jar:</exclude>
                       <exclude>org.apache.hadoop:hadoop-annotations:jar:</exclude>
                       <exclude>org.apache.hadoop:hadoop-auth:jar:</exclude>
                       <exclude>org.apache.hadoop:hadoop-mapreduce-client-common:jar:</exclude>

--- a/src/main/java/org/apache/accumulo/examples/util/FormatUtil.java
+++ b/src/main/java/org/apache/accumulo/examples/util/FormatUtil.java
@@ -35,7 +35,7 @@ public final class FormatUtil {
    * Examples: <br/>
    * {@literal a ~chunk:\x00\x00\x00d\x00\x00\x00\x00 [A&B] 9223372036854775807 asdfjkl;}
    * {@literal a ~chunk:\x00\x00\x00d\x00\x00\x00\x00 [A&B] asdfjkl;}
-   * 
+   *
    * @param entry
    *          the table entry to format
    * @param includeTimestamp


### PR DESCRIPTION
* Update README to refer to lib/ directory (lib/ext/ is no longer
  expected to exist by default)
* Add some color to the log output
* Rename log4j configuration file so it uses a name that is recognized
  as a properties file so log4j doesn't try to parse it as XML, this
  rename also allows it to be loaded from the CLASSPATH
* Use CLASSPATH environment instead of `-cp` option
* Set up class path to include the Accumulo lib/ directory so it doesn't
  complain about missing log4j runtime libraries (This fixes #86)
* Update pom.xml by updating ZK version, removing accumulo-tracer, and
  bumping plugin versions
* Fix shading warning due to migration of javax.activation-api to
  jakarta.activation-api