### PR TITLE
Fix slf4j dependency collision

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,8 @@
                       <exclude>org.apache.logging.log4j:log4j-api:jar:</exclude>
                       <exclude>org.apache.logging.log4j:log4j-1.2-api:jar:</exclude>
                       <exclude>org.apache.logging.log4j:log4j-slf4j-impl:jar:</exclude>
+                      <exclude>org.slf4j:slf4j-api:jar:</exclude>
+                      <exclude>log4j:log4j:jar:</exclude>
                       <exclude>jakarta.activation:jakarta.activation-api:jar:</exclude>
                       <exclude>org.apache.hadoop:hadoop-annotations:jar:</exclude>
                       <exclude>org.apache.hadoop:hadoop-auth:jar:</exclude>


### PR DESCRIPTION
Fixes #89 

Adding these two exclusions for the shaded jar  solve the issue I was seeing in #89. All Logging in the examples seems to work as expected.