### PR TITLE
Update log4j-slf4j and hadoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <accumulo.version>2.1.0-SNAPSHOT</accumulo.version>
     <eclipseFormatterStyle>contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -100,7 +100,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>runtime</scope>
     </dependency>
     <!-- Test dependencies -->


### PR DESCRIPTION
Logging does not work without upgrading log4j-slf4j to log4j-slf4j2. This PR also updates to the current version of hadoop in the main accumulo repo.