### PR TITLE
Bring some dependency versions up to date with main accumulo project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>24</version>
+    <version>27</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-examples</artifactId>
@@ -38,7 +38,7 @@
     <minimalMavenBuildVersion>3.5.0</minimalMavenBuildVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2020-12-17T22:06:50Z</project.build.outputTimestamp>
-    <zookeeper.version>3.7.0</zookeeper.version>
+    <zookeeper.version>3.8.0</zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -134,7 +134,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.2.0</version>
           <configuration>
             <createBackupFile>false</createBackupFile>
             <expandEmptyElements>false</expandEmptyElements>
@@ -156,7 +156,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.1.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -197,7 +197,7 @@
         <!-- This was added to ensure project only uses public API -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
         <configuration>
           <configLocation>contrib/checkstyle.xml</configLocation>
         </configuration>
@@ -205,7 +205,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>9.3</version>
+            <version>10.3.4</version>
           </dependency>
         </dependencies>
         <executions>
@@ -220,7 +220,7 @@
       <plugin>
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
-        <version>1.6.2</version>
+        <version>1.7.0</version>
         <configuration>
           <removeUnused>true</removeUnused>
           <groups>java.,javax.,jakarta.,org.,com.</groups>
@@ -258,7 +258,7 @@
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
         <artifactId>formatter-maven-plugin</artifactId>
-        <version>2.18.0</version>
+        <version>2.20.0</version>
         <configuration>
           <configFile>${eclipseFormatterStyle}</configFile>
           <lineEnding>LF</lineEnding>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.1.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -153,10 +153,6 @@
           <artifactId>maven-dependency-plugin</artifactId>
           <version>3.3.0</version>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
The following versions were bumped to match the main accumulo project dependency versions:
* parent version
* zookeeper
* sortpom-maven-plugin
* maven-enforcer-plugin
* maven-checkstyle-plugin
* puppycrawl
* impsort-maven-plugin
* formatter-maven-plugin