### PR TITLE
Update POM to target 2.1.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-examples</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.1.1-SNAPSHOT</version>
   <name>Apache Accumulo Examples</name>
   <description>Example code and corresponding documentation for using Apache Accumulo</description>
   <properties>
-    <accumulo.version>2.1.0-SNAPSHOT</accumulo.version>
+    <accumulo.version>2.1.1-SNAPSHOT</accumulo.version>
     <eclipseFormatterStyle>contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <hadoop.version>3.3.4</hadoop.version>
     <maven.compiler.release>11</maven.compiler.release>


### PR DESCRIPTION
With the release of 2.1.0, the main Accumulo branch is now targeted for 3.x development. 
The current accumulo-examples repo targets the 2.1.x line. This updates the POM such that the 2.1 examples branch runs against the 2.1.1-SNAPSHOT version of the main Accumulo repository.