### PR TITLE
Update accumulo-examples to target 3.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,11 @@
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-examples</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Apache Accumulo Examples</name>
   <description>Example code and corresponding documentation for using Apache Accumulo</description>
   <properties>
-    <accumulo.version>2.1.0-SNAPSHOT</accumulo.version>
+    <accumulo.version>3.0.0-SNAPSHOT</accumulo.version>
     <eclipseFormatterStyle>contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
     <hadoop.version>3.3.4</hadoop.version>
     <maven.compiler.release>11</maven.compiler.release>


### PR DESCRIPTION
The main branch of the accumulo-example repository should now target the current development branch of Accumulo, which is 3.0.0-SNAPSHOT.

A 2.1 branch has been created that will continue to target the 2.1.x line of Accumulo.

Note that this will not currently pass checks as the examples will need updating for the new line of development.