### PR TITLE
Remove log4j-core dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
The log4j version was updated in https://github.com/apache/accumulo/pull/3215 which fixes a bug that required log4j-core to be present. With the new version now being tracked in accumulo-examples, this import is no longer needed.