### PR TITLE
Add overloaded Common.createTableWithNamespace() with NTC

### DIFF
--- a/src/main/java/org/apache/accumulo/examples/Common.java
+++ b/src/main/java/org/apache/accumulo/examples/Common.java
@@ -37,7 +37,8 @@ public class Common {
   }
 
   public static void createTableWithNamespace(final AccumuloClient client, final String table,
-      final NewTableConfiguration ntc) throws AccumuloException, AccumuloSecurityException {
+      final NewTableConfiguration newTableConfig)
+      throws AccumuloException, AccumuloSecurityException {
     String[] name = table.split("\\.");
     if (name.length == 2 && !name[0].isEmpty()) {
       try {
@@ -47,7 +48,7 @@ public class Common {
       }
     }
     try {
-      client.tableOperations().create(table, ntc);
+      client.tableOperations().create(table, newTableConfig);
     } catch (TableExistsException e) {
       log.warn(TABLE_EXISTS_MSG + table);
     }

--- a/src/main/java/org/apache/accumulo/examples/Common.java
+++ b/src/main/java/org/apache/accumulo/examples/Common.java
@@ -5,6 +5,7 @@ import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.NamespaceExistsException;
 import org.apache.accumulo.core.client.TableExistsException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +33,11 @@ public class Common {
    */
   public static void createTableWithNamespace(final AccumuloClient client, final String table)
       throws AccumuloException, AccumuloSecurityException {
+    createTableWithNamespace(client, table, new NewTableConfiguration());
+  }
+
+  public static void createTableWithNamespace(final AccumuloClient client, final String table,
+      final NewTableConfiguration ntc) throws AccumuloException, AccumuloSecurityException {
     String[] name = table.split("\\.");
     if (name.length == 2 && !name[0].isEmpty()) {
       try {
@@ -41,7 +47,7 @@ public class Common {
       }
     }
     try {
-      client.tableOperations().create(table);
+      client.tableOperations().create(table, ntc);
     } catch (TableExistsException e) {
       log.warn(TABLE_EXISTS_MSG + table);
     }

--- a/src/main/java/org/apache/accumulo/examples/bloom/BloomFilters.java
+++ b/src/main/java/org/apache/accumulo/examples/bloom/BloomFilters.java
@@ -61,8 +61,8 @@ public final class BloomFilters {
       final String tableName) throws AccumuloException, AccumuloSecurityException {
     log.info("Creating {}", tableName);
     Map<String,String> props = Map.of("table.compaction.major.ratio", "7");
-    var ntc = new NewTableConfiguration().setProperties(props);
-    Common.createTableWithNamespace(client, tableName, ntc);
+    var newTableConfig = new NewTableConfiguration().setProperties(props);
+    Common.createTableWithNamespace(client, tableName, newTableConfig);
   }
 
   // Write a million rows 3 times flushing files to disk separately

--- a/src/main/java/org/apache/accumulo/examples/bloom/BloomFilters.java
+++ b/src/main/java/org/apache/accumulo/examples/bloom/BloomFilters.java
@@ -16,6 +16,7 @@
  */
 package org.apache.accumulo.examples.bloom;
 
+import java.util.Map;
 import java.util.Random;
 
 import org.apache.accumulo.core.client.Accumulo;
@@ -25,6 +26,7 @@ import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.security.ColumnVisibility;
 import org.apache.accumulo.examples.Common;
@@ -58,8 +60,9 @@ public final class BloomFilters {
   private static void createTableAndSetCompactionRatio(AccumuloClient client,
       final String tableName) throws AccumuloException, AccumuloSecurityException {
     log.info("Creating {}", tableName);
-    Common.createTableWithNamespace(client, tableName);
-    client.tableOperations().setProperty(tableName, "table.compaction.major.ratio", "7");
+    Map<String,String> props = Map.of("table.compaction.major.ratio", "7");
+    var ntc = new NewTableConfiguration().setProperties(props);
+    Common.createTableWithNamespace(client, tableName, ntc);
   }
 
   // Write a million rows 3 times flushing files to disk separately

--- a/src/main/java/org/apache/accumulo/examples/bloom/BloomFiltersNotFound.java
+++ b/src/main/java/org/apache/accumulo/examples/bloom/BloomFiltersNotFound.java
@@ -18,11 +18,14 @@ package org.apache.accumulo.examples.bloom;
 
 import static org.apache.accumulo.examples.bloom.BloomFilters.writeData;
 
+import java.util.Map;
+
 import org.apache.accumulo.core.client.Accumulo;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.examples.Common;
 import org.apache.accumulo.examples.cli.ClientOpts;
 import org.slf4j.Logger;
@@ -38,10 +41,11 @@ public class BloomFiltersNotFound {
     opts.parseArgs(BloomFiltersNotFound.class.getName(), args);
 
     try (AccumuloClient client = Accumulo.newClient().from(opts.getClientPropsPath()).build()) {
+      Map<String,String> props = Map.of(BloomCommon.BLOOM_ENABLED_PROPERTY, "true");
+      var ntc = new NewTableConfiguration().setProperties(props);
+
       Common.createTableWithNamespace(client, BloomCommon.BLOOM_TEST3_TABLE);
-      Common.createTableWithNamespace(client, BloomCommon.BLOOM_TEST4_TABLE);
-      client.tableOperations().setProperty(BloomCommon.BLOOM_TEST4_TABLE,
-          BloomCommon.BLOOM_ENABLED_PROPERTY, "true");
+      Common.createTableWithNamespace(client, BloomCommon.BLOOM_TEST4_TABLE, ntc);
 
       writeAndFlush(BloomCommon.BLOOM_TEST3_TABLE, client);
       writeAndFlush(BloomCommon.BLOOM_TEST4_TABLE, client);

--- a/src/main/java/org/apache/accumulo/examples/bloom/BloomFiltersNotFound.java
+++ b/src/main/java/org/apache/accumulo/examples/bloom/BloomFiltersNotFound.java
@@ -42,10 +42,10 @@ public class BloomFiltersNotFound {
 
     try (AccumuloClient client = Accumulo.newClient().from(opts.getClientPropsPath()).build()) {
       Map<String,String> props = Map.of(BloomCommon.BLOOM_ENABLED_PROPERTY, "true");
-      var ntc = new NewTableConfiguration().setProperties(props);
+      var newTableConfig = new NewTableConfiguration().setProperties(props);
 
       Common.createTableWithNamespace(client, BloomCommon.BLOOM_TEST3_TABLE);
-      Common.createTableWithNamespace(client, BloomCommon.BLOOM_TEST4_TABLE, ntc);
+      Common.createTableWithNamespace(client, BloomCommon.BLOOM_TEST4_TABLE, newTableConfig);
 
       writeAndFlush(BloomCommon.BLOOM_TEST3_TABLE, client);
       writeAndFlush(BloomCommon.BLOOM_TEST4_TABLE, client);

--- a/src/main/java/org/apache/accumulo/examples/dirlist/Ingest.java
+++ b/src/main/java/org/apache/accumulo/examples/dirlist/Ingest.java
@@ -161,12 +161,12 @@ public final class Ingest {
     opts.parseArgs(Ingest.class.getName(), args, bwOpts);
 
     try (AccumuloClient client = opts.createAccumuloClient()) {
-      var ntc = new NewTableConfiguration()
+      var newTableConfig = new NewTableConfiguration()
           .attachIterator(new IteratorSetting(1, ChunkCombiner.class));
 
       Common.createTableWithNamespace(client, opts.dirTable);
       Common.createTableWithNamespace(client, opts.indexTable);
-      Common.createTableWithNamespace(client, opts.dataTable, ntc);
+      Common.createTableWithNamespace(client, opts.dataTable, newTableConfig);
 
       BatchWriter dirBW = client.createBatchWriter(opts.dirTable, bwOpts.getBatchWriterConfig());
       BatchWriter indexBW = client.createBatchWriter(opts.indexTable,

--- a/src/main/java/org/apache/accumulo/examples/dirlist/Ingest.java
+++ b/src/main/java/org/apache/accumulo/examples/dirlist/Ingest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.client.lexicoder.Encoder;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
@@ -158,11 +159,12 @@ public final class Ingest {
     opts.parseArgs(Ingest.class.getName(), args, bwOpts);
 
     try (AccumuloClient client = opts.createAccumuloClient()) {
+      var ntc = new NewTableConfiguration()
+          .attachIterator(new IteratorSetting(1, ChunkCombiner.class));
+
       Common.createTableWithNamespace(client, opts.dirTable);
       Common.createTableWithNamespace(client, opts.indexTable);
-      Common.createTableWithNamespace(client, opts.dataTable);
-      client.tableOperations().attachIterator(opts.dataTable,
-          new IteratorSetting(1, ChunkCombiner.class));
+      Common.createTableWithNamespace(client, opts.dataTable, ntc);
 
       BatchWriter dirBW = client.createBatchWriter(opts.dirTable, bwOpts.getBatchWriterConfig());
       BatchWriter indexBW = client.createBatchWriter(opts.indexTable,

--- a/src/main/java/org/apache/accumulo/examples/filedata/FileDataIngest.java
+++ b/src/main/java/org/apache/accumulo/examples/filedata/FileDataIngest.java
@@ -28,6 +28,7 @@ import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchWriter;
 import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.MutationsRejectedException;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.data.ArrayByteSequence;
 import org.apache.accumulo.core.data.ByteSequence;
 import org.apache.accumulo.core.data.Mutation;
@@ -199,9 +200,8 @@ public class FileDataIngest {
     opts.parseArgs(FileDataIngest.class.getName(), args, bwOpts);
 
     try (AccumuloClient client = opts.createAccumuloClient()) {
-      Common.createTableWithNamespace(client, opts.getTableName());
-      client.tableOperations().attachIterator(opts.getTableName(),
-          new IteratorSetting(1, ChunkCombiner.class));
+      Common.createTableWithNamespace(client, opts.getTableName(),
+          new NewTableConfiguration().attachIterator(new IteratorSetting(1, ChunkCombiner.class)));
 
       try (BatchWriter bw = client.createBatchWriter(opts.getTableName(),
           bwOpts.getBatchWriterConfig())) {

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/NGramIngest.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/NGramIngest.java
@@ -19,8 +19,11 @@ package org.apache.accumulo.examples.mapreduce;
 import java.io.IOException;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.accumulo.core.client.AccumuloClient;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.data.Value;
 import org.apache.accumulo.examples.Common;
@@ -89,18 +92,17 @@ public class NGramIngest {
 
     try (AccumuloClient client = opts.createAccumuloClient()) {
       if (!client.tableOperations().exists(opts.tableName)) {
-        log.info("Creating table " + opts.tableName);
-        Common.createTableWithNamespace(client, opts.tableName);
-        SortedSet<Text> splits = new TreeSet<>();
         String[] numbers = "1 2 3 4 5 6 7 8 9".split("\\s");
         String[] lower = "a b c d e f g h i j k l m n o p q r s t u v w x y z".split("\\s");
         String[] upper = "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z".split("\\s");
-        for (String[] array : new String[][] {numbers, lower, upper}) {
-          for (String s : array) {
-            splits.add(new Text(s));
-          }
-        }
-        client.tableOperations().addSplits(opts.tableName, splits);
+
+        SortedSet<Text> splits = Stream.of(numbers, lower, upper).flatMap(Stream::of).map(Text::new)
+            .collect(Collectors.toCollection(TreeSet::new));
+
+        var ntc = new NewTableConfiguration().withSplits(splits);
+
+        log.info("Creating table " + opts.tableName);
+        Common.createTableWithNamespace(client, opts.tableName, ntc);
       }
     }
 

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/NGramIngest.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/NGramIngest.java
@@ -99,10 +99,10 @@ public class NGramIngest {
         SortedSet<Text> splits = Stream.of(numbers, lower, upper).flatMap(Stream::of).map(Text::new)
             .collect(Collectors.toCollection(TreeSet::new));
 
-        var ntc = new NewTableConfiguration().withSplits(splits);
+        var newTableConfig = new NewTableConfiguration().withSplits(splits);
 
         log.info("Creating table " + opts.tableName);
-        Common.createTableWithNamespace(client, opts.tableName, ntc);
+        Common.createTableWithNamespace(client, opts.tableName, newTableConfig);
       }
     }
 

--- a/src/main/java/org/apache/accumulo/examples/mapreduce/WordCount.java
+++ b/src/main/java/org/apache/accumulo/examples/mapreduce/WordCount.java
@@ -23,6 +23,7 @@ import java.util.Date;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.client.admin.NewTableConfiguration;
 import org.apache.accumulo.core.data.Mutation;
 import org.apache.accumulo.core.iterators.user.SummingCombiner;
 import org.apache.accumulo.examples.Common;
@@ -81,14 +82,14 @@ public final class WordCount {
     Opts opts = new Opts();
     opts.parseArgs(WordCount.class.getName(), args);
 
-    // Create Accumulo table and attach Summing iterator
+    // Create Accumulo table with Summing iterator attached
     try (AccumuloClient client = opts.createAccumuloClient()) {
-      Common.createTableWithNamespace(client, opts.tableName);
       IteratorSetting is = new IteratorSetting(10, SummingCombiner.class);
       SummingCombiner.setColumns(is,
           Collections.singletonList(new IteratorSetting.Column("count")));
       SummingCombiner.setEncodingType(is, SummingCombiner.Type.STRING);
-      client.tableOperations().attachIterator(opts.tableName, is);
+      Common.createTableWithNamespace(client, opts.tableName,
+          new NewTableConfiguration().attachIterator(is));
     }
 
     // Create M/R job


### PR DESCRIPTION
This PR adds an overloaded version of  Common.createTableWithNamespace() that accept a `NewTableConfiguration` object as a parameter. I've also tried to make use of this new method where it seems useful to do so.