### PR TITLE
Bump accumulo, zookeeper, hadoop and other versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>27</version>
+    <version>30</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-examples</artifactId>
@@ -28,9 +28,9 @@
   <name>Apache Accumulo Examples</name>
   <description>Example code and corresponding documentation for using Apache Accumulo</description>
   <properties>
-    <accumulo.version>3.0.0-SNAPSHOT</accumulo.version>
+    <accumulo.version>3.1.0-SNAPSHOT</accumulo.version>
     <eclipseFormatterStyle>contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
-    <hadoop.version>3.3.4</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <maven.compiler.release>11</maven.compiler.release>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -38,7 +38,7 @@
     <minimalMavenBuildVersion>3.5.0</minimalMavenBuildVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2020-12-17T22:06:50Z</project.build.outputTimestamp>
-    <zookeeper.version>3.8.0</zookeeper.version>
+    <zookeeper.version>3.8.3</zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -146,7 +146,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.3.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -195,7 +194,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.3.4</version>
+            <version>10.12.2</version>
           </dependency>
         </dependencies>
         <executions>
@@ -210,7 +209,7 @@
       <plugin>
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
-        <version>1.8.0</version>
+        <version>1.9.0</version>
         <configuration>
           <removeUnused>true</removeUnused>
           <groups>java.,javax.,jakarta.,org.,com.</groups>
@@ -248,7 +247,7 @@
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
         <artifactId>formatter-maven-plugin</artifactId>
-        <version>2.20.0</version>
+        <version>2.23.0</version>
         <configuration>
           <configFile>${eclipseFormatterStyle}</configFile>
           <lineEnding>LF</lineEnding>


### PR DESCRIPTION
Updates versions to match the accumulo repo.
Removed version number for `maven-dependency-plugin` as it is covered in the parent pom