### PR TITLE
Update repo to match accumulo 4.0

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -39,11 +39,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 17
+        java-version: 21
         cache: 'maven'
     - name: Build with Maven (${{ matrix.profile.name }})
       run: mvn -B -V -e -ntp "-Dstyle.color=always" ${{ matrix.profile.args }}
@@ -70,4 +70,3 @@ jobs:
         name: mini-tests-logs-${{ matrix.profile.name }}
         path: ./**/target/**/mini-tests/**/logs/
         if-no-files-found: ignore
-

--- a/conf/env.sh.example
+++ b/conf/env.sh.example
@@ -32,7 +32,7 @@ conf_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # Versions set below will be what is included in the shaded jar
 export ACCUMULO_VERSION="`$ACCUMULO_HOME/bin/accumulo version`"
 export HADOOP_VERSION="`$HADOOP_HOME/bin/hadoop version | head -n1 | awk '{print $2}'`"
-export ZOOKEEPER_VERSION=3.7.0
+export ZOOKEEPER_VERSION=3.9.5
 # Path to shaded test jar
 ex_home=$( cd "$( dirname "$conf_dir" )" && pwd )
 export EXAMPLES_JAR_PATH="${ex_home}/target/accumulo-examples-shaded.jar"

--- a/pom.xml
+++ b/pom.xml
@@ -20,24 +20,24 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>31</version>
+    <version>37</version>
   </parent>
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-examples</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
   <name>Apache Accumulo Examples</name>
   <description>Example code and corresponding documentation for using Apache Accumulo</description>
   <properties>
-    <accumulo.version>3.1.0-SNAPSHOT</accumulo.version>
+    <accumulo.version>4.0.0-SNAPSHOT</accumulo.version>
     <eclipseFormatterStyle>contrib/Eclipse-Accumulo-Codestyle.xml</eclipseFormatterStyle>
-    <hadoop.version>3.3.6</hadoop.version>
-    <maven.compiler.release>11</maven.compiler.release>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <minimalJavaBuildVersion>11</minimalJavaBuildVersion>
+    <hadoop.version>3.4.2</hadoop.version>
+    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
     <!-- timestamp for reproducible outputs, updated on release by the release plugin -->
     <project.build.outputTimestamp>2020-12-17T22:06:50Z</project.build.outputTimestamp>
-    <zookeeper.version>3.8.3</zookeeper.version>
+    <zookeeper.version>3.9.5</zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -185,7 +185,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.12.2</version>
+            <version>11.0.1</version>
           </dependency>
         </dependencies>
         <executions>
@@ -200,7 +200,7 @@
       <plugin>
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
-        <version>1.9.0</version>
+        <version>1.13.0</version>
         <configuration>
           <removeUnused>true</removeUnused>
           <groups>java.,javax.,jakarta.,org.,com.</groups>
@@ -238,7 +238,7 @@
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
         <artifactId>formatter-maven-plugin</artifactId>
-        <version>2.23.0</version>
+        <version>2.29.0</version>
         <configuration>
           <configFile>${eclipseFormatterStyle}</configFile>
           <lineEnding>LF</lineEnding>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>apache.snapshots</id>
+      <name>Apache Snapshot Repository</name>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
   <build>
     <finalName>${project.artifactId}</finalName>
     <pluginManagement>

--- a/src/main/java/org/apache/accumulo/examples/shard/ContinuousQuery.java
+++ b/src/main/java/org/apache/accumulo/examples/shard/ContinuousQuery.java
@@ -79,7 +79,7 @@ public class ContinuousQuery {
           bs.clearScanIterators();
           bs.clearColumns();
 
-          IteratorSetting ii = new IteratorSetting(20, "ii", IntersectingIterator.class);
+          IteratorSetting ii = new IteratorSetting(30, "ii", IntersectingIterator.class);
           IntersectingIterator.setColumnFamilies(ii, columns);
           bs.addScanIterator(ii);
           bs.setRanges(Collections.singleton(new Range()));

--- a/src/main/java/org/apache/accumulo/examples/shard/Query.java
+++ b/src/main/java/org/apache/accumulo/examples/shard/Query.java
@@ -70,10 +70,10 @@ public class Query {
     IteratorSetting ii;
 
     if (cutoff != null) {
-      ii = new IteratorSetting(20, "ii", CutoffIntersectingIterator.class);
+      ii = new IteratorSetting(30, "ii", CutoffIntersectingIterator.class);
       CutoffIntersectingIterator.setCutoff(ii, cutoff);
     } else {
-      ii = new IteratorSetting(20, "ii", IntersectingIterator.class);
+      ii = new IteratorSetting(30, "ii", IntersectingIterator.class);
     }
 
     IntersectingIterator.setColumnFamilies(ii, columns);


### PR DESCRIPTION
This PR adds two changes:

fd7e443b4cb8af9b57cc684c5c21c64c18fb08ee to align versions in the pom to those in the main accumulo repo pom

08c74d1760f5d7020967e738851a6f70363720fc avoid iterator priority collision from internal iter 