### PR TITLE
Updated 2 commands in Bloom Filter Example that were outdated

### DIFF
--- a/conf/env.sh.example
+++ b/conf/env.sh.example
@@ -17,9 +17,9 @@
 # =======
 
 ## Hadoop installation
-export HADOOP_HOME="${HADOOP_HOME:-/path/to/hadoop}"
+export HADOOP_HOME="$/home/avillarreal/Desktop/github/accumulo-fluo-uno/install/hadoop-3.5.0/"
 ## Accumulo installation
-export ACCUMULO_HOME="${ACCUMULO_HOME:-/path/to/accumulo}"
+export ACCUMULO_HOME="$/home/avillarreal/Desktop/github/accumulo-fluo-uno/install/accumulo-4.0.0-SNAPSHOT/"
 ## Path to Accumulo client properties
 export ACCUMULO_CLIENT_PROPS="$ACCUMULO_HOME/conf/accumulo-client.properties"
 

--- a/conf/env.sh.example
+++ b/conf/env.sh.example
@@ -17,9 +17,9 @@
 # =======
 
 ## Hadoop installation
-export HADOOP_HOME="$/home/avillarreal/Desktop/github/accumulo-fluo-uno/install/hadoop-3.5.0/"
+export HADOOP_HOME="${HADOOP_HOME:-/path/to/hadoop}"
 ## Accumulo installation
-export ACCUMULO_HOME="$/home/avillarreal/Desktop/github/accumulo-fluo-uno/install/accumulo-4.0.0-SNAPSHOT/"
+export ACCUMULO_HOME="${ACCUMULO_HOME:-/path/to/accumulo}"
 ## Path to Accumulo client properties
 export ACCUMULO_CLIENT_PROPS="$ACCUMULO_HOME/conf/accumulo-client.properties"
 

--- a/docs/bloom.md
+++ b/docs/bloom.md
@@ -49,7 +49,7 @@ likely contain entries for the query, all files will be interrogated.
 You can verify the table has three or more r-files by looking in HDFS. To look in HDFS
 you will need the table ID, which can be found with the following shell command.
 
-    $ accumulo shell -u username -p password -e 'tables -l'
+    $ accumulo shell --user root --password secret -e 'tables -l'
     accumulo.metadata    =>        !0
     accumulo.root        =>        +r
     examples.bloom_test1 =>         2
@@ -68,7 +68,7 @@ table has in HDFS. This assumes Accumulo is at the default location in HDFS.
 Running the rfile-info command shows that one of the files has a bloom filter
 and its 1.5MB.
 
-    $ accumulo rfile-info /accumulo/tables/3/default_tablet/F00000dj.rf
+    $ accumulo file rfile-info /accumulo/tables/3/default_tablet/F00000dj.rf
     Locality group         : <DEFAULT>
 	Start block          : 0
 	Num   blocks         : 752


### PR DESCRIPTION
2 commands in bloom.md were outdated

$ accumulo shell -u username -p password -e 'tables -l'       (-u and -p updated to --user --password respectively, filled actual username and password)

$ accumulo rfile-info /accumulo/tables/3/default_tablet/F00000dj.rf     (missing keyword "file" after "accumulo")