### PR TITLE
Updated commands in Classpath Example that were outdated

### DIFF
--- a/docs/classpath.md
+++ b/docs/classpath.md
@@ -17,10 +17,8 @@ limitations under the License.
 # Apache Accumulo Classpath Example
 
 This example shows how to use per table classpaths. The example leverages a
-test jar which contains a Filter that suppresses rows containing "foo". The
-example shows copying the FooFilter.jar into HDFS and then making an Accumulo
-table reference that jar. For this example.
-   
+test jar which contains a Filter that suppresses rows containing "foo". 
+
 Create a namespace and table
 
     root@uno> createnamespace examples

--- a/docs/classpath.md
+++ b/docs/classpath.md
@@ -18,16 +18,16 @@ limitations under the License.
 
 This example shows how to use per table classpaths. The example leverages a
 test jar which contains a Filter that suppresses rows containing "foo". The
-example shows configuring a table to reference the jar using the built-in
-URL-based context class loader. Note that the `FooFilter.jar`
-is located within the Accumulo source distribution.
+example shows configuring a table to load classes from the jar using the
+URL-based context class loader. Note that the `FooFilter.jar` is located within
+the Accumulo source distribution.
 
 Create a namespace and table
 
     root@uno> createnamespace examples
     root@uno> createtable examples.nofoo
 
-The following command makes this table use the jar URL as its class loader context.
+The following command configures the table to load classes from the jar URL.
 
     root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=file:///path/to/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
 
@@ -46,17 +46,15 @@ The commands below show the filter is working.
     root@uno examples.nofoo>
 
 Below, an attempt is made to add the FooFilter to a table that's not configured
-to use the jar URL as its classpath context. This fails until the table is configured to
-use the jar URL.
+to load classes from the jar URL. This fails until the table is configured with
+the jar URL.
 
     root@uno examples.nofoo> createtable examples.nofootwo
     root@uno examples.nofootwo> setiter -n foofilter -p 10 -scan -minc -majc -class org.apache.accumulo.test.FooFilter
         2013-05-03 12:49:35,943 [shell.Shell] ERROR: org.apache.accumulo.shell.ShellCommandException: Command could 
     not be initialized (Unable to load org.apache.accumulo.test.FooFilter; class not found.)
     root@uno examples.nofootwo> config -t examples.nofootwo -s table.class.loader.context=file:///path/to/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
-
     root@uno examples.nofootwo> setiter -n foofilter -p 10 -scan -minc -majc -class org.apache.accumulo.test.FooFilter
     Filter accepts or rejects each Key/Value pair
     ----------> set FooFilter parameter negate, default false keeps k/v that pass accept method, true rejects k/v that pass accept method: false
-
 

--- a/docs/classpath.md
+++ b/docs/classpath.md
@@ -29,7 +29,7 @@ Create a namespace and table
 
 The following command makes this table use the jar URL as its class loader context.
 
-    root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=file:///path/to/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
+    root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=file:///path/to/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
 
 The following command configures an iterator that's in FooFilter.jar
 
@@ -53,7 +53,7 @@ use the jar URL.
     root@uno examples.nofootwo> setiter -n foofilter -p 10 -scan -minc -majc -class org.apache.accumulo.test.FooFilter
         2013-05-03 12:49:35,943 [shell.Shell] ERROR: org.apache.accumulo.shell.ShellCommandException: Command could 
     not be initialized (Unable to load org.apache.accumulo.test.FooFilter; class not found.)
-    root@uno examples.nofootwo> config -t examples.nofootwo -s table.class.loader.context=file:///path/to/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
+    root@uno examples.nofootwo> config -t examples.nofootwo -s table.class.loader.context=file:///path/to/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
 
     root@uno examples.nofootwo> setiter -n foofilter -p 10 -scan -minc -majc -class org.apache.accumulo.test.FooFilter
     Filter accepts or rejects each Key/Value pair

--- a/docs/classpath.md
+++ b/docs/classpath.md
@@ -17,7 +17,9 @@ limitations under the License.
 # Apache Accumulo Classpath Example
 
 This example shows how to use per table classpaths. The example leverages a
-test jar which contains a Filter that suppresses rows containing "foo". 
+test jar which contains a Filter that suppresses rows containing "foo". The
+example shows configuring a table to reference the jar using the built-in
+URL-based context class loader.
 
 Create a namespace and table
 
@@ -26,7 +28,7 @@ Create a namespace and table
 
 The following command makes this table use the configured classpath context to `FooFilter.jar`
 
-    root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=file://<your-root-directory>/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
+    root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=file:///path/to/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
 
 The following command configures an iterator that's in FooFilter.jar
 
@@ -43,14 +45,14 @@ The commands below show the filter is working.
     root@uno examples.nofoo>
 
 Below, an attempt is made to add the FooFilter to a table that's not configured
-to use the classpath context cx1. This fails until the table is configured to
-use cx1.
+to use the jar URL as its classpath context. This fails until the table is configured to
+use the jar URL.
 
     root@uno examples.nofoo> createtable examples.nofootwo
     root@uno examples.nofootwo> setiter -n foofilter -p 10 -scan -minc -majc -class org.apache.accumulo.test.FooFilter
         2013-05-03 12:49:35,943 [shell.Shell] ERROR: org.apache.accumulo.shell.ShellCommandException: Command could 
     not be initialized (Unable to load org.apache.accumulo.test.FooFilter; class not found.)
-    root@uno examples.nofootwo> config -t examples.nofootwo -s table.class.loader.context=file://<your-root-directory>/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
+    root@uno examples.nofootwo> config -t examples.nofootwo -s table.class.loader.context=file:///path/to/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
 
     root@uno examples.nofootwo> setiter -n foofilter -p 10 -scan -minc -majc -class org.apache.accumulo.test.FooFilter
     Filter accepts or rejects each Key/Value pair

--- a/docs/classpath.md
+++ b/docs/classpath.md
@@ -19,30 +19,16 @@ limitations under the License.
 This example shows how to use per table classpaths. The example leverages a
 test jar which contains a Filter that suppresses rows containing "foo". The
 example shows copying the FooFilter.jar into HDFS and then making an Accumulo
-table reference that jar. For this example, a directory, `/user1/lib`, is
-assumed to exist in HDFS.
-
-Create `/user1/lib` in HDFS if it does not exist.
-
-    hadoop fs -mkdir -p /user1/lib
-
-Execute the following command in the shell. Note that the `FooFilter.jar`
-is located within the Accumulo source distribution. 
-
-    $ hadoop fs -copyFromLocal /path/to/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar /user1/lib
-
-Execute following in Accumulo shell to setup classpath context
-
-    root@uno> config -s general.vfs.context.classpath.cx1=hdfs://<namenode host>:<namenode port>/user1/lib/[^.].*.jar
-
+table reference that jar. For this example.
+   
 Create a namespace and table
 
     root@uno> createnamespace examples
     root@uno> createtable examples.nofoo
 
-The following command makes this table use the configured classpath context
+The following command makes this table use the configured classpath context to `FooFilter.jar`
 
-    root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=cx1
+    root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=file://<your-root-directory>/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
 
 The following command configures an iterator that's in FooFilter.jar
 
@@ -66,7 +52,8 @@ use cx1.
     root@uno examples.nofootwo> setiter -n foofilter -p 10 -scan -minc -majc -class org.apache.accumulo.test.FooFilter
         2013-05-03 12:49:35,943 [shell.Shell] ERROR: org.apache.accumulo.shell.ShellCommandException: Command could 
     not be initialized (Unable to load org.apache.accumulo.test.FooFilter; class not found.)
-    root@uno examples.nofootwo> config -t examples.nofootwo -s table.class.loader.context=cx1
+    root@uno examples.nofootwo> config -t examples.nofootwo -s table.class.loader.context=file://<your-root-directory>/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
+
     root@uno examples.nofootwo> setiter -n foofilter -p 10 -scan -minc -majc -class org.apache.accumulo.test.FooFilter
     Filter accepts or rejects each Key/Value pair
     ----------> set FooFilter parameter negate, default false keeps k/v that pass accept method, true rejects k/v that pass accept method: false

--- a/docs/classpath.md
+++ b/docs/classpath.md
@@ -19,14 +19,15 @@ limitations under the License.
 This example shows how to use per table classpaths. The example leverages a
 test jar which contains a Filter that suppresses rows containing "foo". The
 example shows configuring a table to reference the jar using the built-in
-URL-based context class loader.
+URL-based context class loader. Note that the `FooFilter.jar`
+is located within the Accumulo source distribution.
 
 Create a namespace and table
 
     root@uno> createnamespace examples
     root@uno> createtable examples.nofoo
 
-The following command makes this table use the configured classpath context to `FooFilter.jar`
+The following command makes this table use the jar URL as its class loader context.
 
     root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=file:///path/to/github/accumulo/test/src/main/resources/org/apache/accumulo/test/FooFilter.jar
 


### PR DESCRIPTION
updated classpath.md,
- removed first 3 commands along with their text instructions
- root@uno examples.nofoo> config -t examples.nofoo -s table.class.loader.context=cx1 was updated to use file path instead of cx1 in 2 locations