### PR TITLE
Updated commands in Delete Key Value Pair and Combiner that were outdated

### DIFF
--- a/docs/combiner.md
+++ b/docs/combiner.md
@@ -20,10 +20,10 @@ This tutorial uses the following Java class, which can be found in org.apache.ac
 
  * [StatsCombiner.java] - a combiner that calculates max, min, sum, and count
 
-This is a simple combiner example. To build this example run maven and then
-copy the produced jar into the accumulo lib dir. This is already done in the
-tar distribution. Restart your Accumulo instance to ensure the .jar is 
-picked up by the tservers.
+This is a simple combiner example. Before running it, follow the
+[setup instructions](../README.md#setup-instructions) so the examples jar is
+available to Accumulo. Restart your Accumulo instance to ensure the jar is
+picked up by the servers.
 
     $ accumulo shell -u root
     Enter current password for 'username'@'instance': ***

--- a/docs/combiner.md
+++ b/docs/combiner.md
@@ -24,7 +24,7 @@ This is a simple combiner example. To build this example run maven and then
 copy the produced jar into the accumulo lib dir. This is already done in the
 tar distribution.
 
-    $ bin/accumulo shell -u username
+    $ accumulo shell -u root
     Enter current password for 'username'@'instance': ***
 
     Shell - Apache Accumulo Interactive Shell
@@ -37,6 +37,7 @@ tar distribution.
     -
     username@instance> createnamespace examples
     username@instance> createtable examples.runners
+    username@instance examples.runners> config -t examples.runners -s table.class.loader.context=file:///path/to/accumulo-examples/target/accumulo-examples.jar
     username@instance examples.runners> setiter -t examples.runners -p 10 -scan -minc -majc -n decStats -class org.apache.accumulo.examples.combiner.StatsCombiner
     Combiner that keeps track of min, max, sum, and count
     ----------> set StatsCombiner parameter all, set to true to apply Combiner to every column, otherwise leave blank. if true, columns option will be ignored.: 

--- a/docs/combiner.md
+++ b/docs/combiner.md
@@ -38,7 +38,6 @@ picked up by the tservers.
     -
     username@instance> createnamespace examples
     username@instance> createtable examples.runners
-    username@instance examples.runners> config -t examples.runners -s table.class.loader.context=file:///path/to/accumulo-examples/target/accumulo-examples.jar
     username@instance examples.runners> setiter -t examples.runners -p 10 -scan -minc -majc -n decStats -class org.apache.accumulo.examples.combiner.StatsCombiner
     Combiner that keeps track of min, max, sum, and count
     ----------> set StatsCombiner parameter all, set to true to apply Combiner to every column, otherwise leave blank. if true, columns option will be ignored.: 

--- a/docs/combiner.md
+++ b/docs/combiner.md
@@ -22,14 +22,15 @@ This tutorial uses the following Java class, which can be found in org.apache.ac
 
 This is a simple combiner example. To build this example run maven and then
 copy the produced jar into the accumulo lib dir. This is already done in the
-tar distribution.
+tar distribution. Restart your Accumulo instance to ensure the .jar is 
+picked up by the tservers.
 
     $ accumulo shell -u root
     Enter current password for 'username'@'instance': ***
 
     Shell - Apache Accumulo Interactive Shell
     -
-    - version: 2.1.0-SNAPSHOT
+    - version: 4.0.0-SNAPSHOT
     - instance name: instance
     - instance id: 00000000-0000-0000-0000-000000000000
     -

--- a/docs/deleteKeyValuePair.md
+++ b/docs/deleteKeyValuePair.md
@@ -60,7 +60,7 @@ username@instance examples.deleteKeyValuePair> scan -t accumulo.metadata -c file
 View the contents of RFile and verify each key-value pair's deletion flag is false.
 
 ```
-$ accumulo file rfile-info -d hdfs://localhost/accumulo/tables/1t/default_tablet/F00007em.rf
+$ accumulo file rfile-info -d hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007em.rf
 RFile Version            : 8
 
 Locality group           : <DEFAULT>
@@ -97,12 +97,12 @@ username@instance examples.deleteKeyValuePair> flush -w
 ```
 username@instance examples.deleteKeyValuePair> scan -t accumulo.metadata -c file -r 1t<
 1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007em.rf","startRow":"","endRow":""} []	311,3
-1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007fg.rf","startRow":"","endRow":""} []	311,3
+1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007fg.rf","startRow":"","endRow":""} []	230,1
 
 ```
 
 ```
-$ accumulo file rfile-info -d hdfs://localhost/accumulo/tables/1t/default_tablet/F00007fq.rf
+$ accumulo file rfile-info -d hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007fq.rf
 RFile Version            : 8
 
 Locality group           : <DEFAULT>
@@ -138,12 +138,12 @@ completed for given range
 
 ```
 username@instance> scan -t accumulo.metadata -c file -r 1t<
-1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/A00007g1.rf","startRow":"","endRow":""} []	311,3
+1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/A00007g1.rf","startRow":"","endRow":""} []	293,2
 
 ```
 
  ```
-$ accumulo file rfile-info -v hdfs://localhost/accumulo/tables/1t/default_tablet/A00007g1.rf
+$ accumulo file rfile-info -v hdfs://localhost:8020/accumulo/tables/1t/default_tablet/A00007g1.rf
 RFile Version            : 8
 
 Locality group           : <DEFAULT>

--- a/docs/deleteKeyValuePair.md
+++ b/docs/deleteKeyValuePair.md
@@ -19,7 +19,7 @@ limitations under the License.
 This example shows how Accumulo internals handle removing a key-value pair
 
 ```
-$ /path/to/accumulo shell -u username -p secret
+$ accumulo shell --user root --password secret
 username@instance> createnamespace examples
 username@instance> createtable examples.deleteKeyValuePair
 username@instance examples.deleteKeyValuePair> insert 567890 name first Joe
@@ -59,7 +59,7 @@ username@instance examples.deleteKeyValuePair> scan -t accumulo.metadata -c file
 View the contents of RFile and verify each key-value pair's deletion flag is false.
 
 ```
-$ /path/to/accumulo rfile-info -d hdfs://localhost/accumulo/tables/1t/default_tablet/F00007em.rf
+$ accumulo file rfile-info -d hdfs://localhost/accumulo/tables/1t/default_tablet/F00007em.rf
 RFile Version            : 8
 
 Locality group           : <DEFAULT>
@@ -87,7 +87,7 @@ Meta block     : RFile.index
 Delete a key-value pair and view a newly created RFile to verify the deletion flag is true.
 
 ```
-$ /path/to/accumulo shell -u username -p secret
+$ accumulo shell --user root --password secret
 username@instance> table examples.deleteKeyValuePair
 username@instance examples.deleteKeyValuePair> delete 567890 name first
 username@instance examples.deleteKeyValuePair> flush -w
@@ -100,7 +100,7 @@ username@instance examples.deleteKeyValuePair> scan -t accumulo.metadata -c file
 ```
 
 ```
-$ /path/to/accumulo rfile-info -d hdfs://localhost/accumulo/tables/1t/default_tablet/F00007fq.rf
+$ accumulo file rfile-info -d hdfs://localhost/accumulo/tables/1t/default_tablet/F00007fq.rf
 RFile Version            : 8
 
 Locality group           : <DEFAULT>
@@ -127,7 +127,7 @@ Meta block     : RFile.index
 Compact the RFiles and verify the key-value pair was removed.  The new RFile will start with 'A'.
 
 ```
-$ /path/to/accumulo shell -u username -p secret
+$ accumulo shell --user root --password secret
 username@instance> compact -t examples.deleteKeyValuePair -w
 2019-04-17 08:17:15,468 [shell.Shell] INFO : Compacting table ...
 2019-04-17 08:17:16,143 [shell.Shell] INFO : Compaction of table examples.deleteKeyValuePair 
@@ -140,7 +140,7 @@ lt< file:hdfs://localhost:8020/accumulo/tables/1t/default_tablet/A00007g1.rf
 ```
 
  ```
-$ /path/to/accumulo rfile-info -v hdfs://localhost/accumulo/tables/1t/default_tablet/A00007g1.rf
+$ accumulo file rfile-info -v hdfs://localhost/accumulo/tables/1t/default_tablet/A00007g1.rf
 RFile Version            : 8
 
 Locality group           : <DEFAULT>

--- a/docs/deleteKeyValuePair.md
+++ b/docs/deleteKeyValuePair.md
@@ -53,7 +53,8 @@ Scan accumulo.metadata table to see the list of RFiles Accumulo is currently usi
 
 ```
 username@instance examples.deleteKeyValuePair> scan -t accumulo.metadata -c file -r 1t<
-1t< file:hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007em.rf
+1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007em.rf","startRow":"","endRow":""} []	311,3
+
 ```
 
 View the contents of RFile and verify each key-value pair's deletion flag is false.
@@ -95,8 +96,9 @@ username@instance examples.deleteKeyValuePair> flush -w
 
 ```
 username@instance examples.deleteKeyValuePair> scan -t accumulo.metadata -c file -r 1t<
-1t< file:hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007em.rf
-1t< file:hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007fq.rf
+1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007em.rf","startRow":"","endRow":""} []	311,3
+1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/F00007fg.rf","startRow":"","endRow":""} []	311,3
+
 ```
 
 ```
@@ -136,7 +138,8 @@ completed for given range
 
 ```
 username@instance> scan -t accumulo.metadata -c file -r 1t<
-lt< file:hdfs://localhost:8020/accumulo/tables/1t/default_tablet/A00007g1.rf
+1t< file:{"path":"hdfs://localhost:8020/accumulo/tables/1t/default_tablet/A00007g1.rf","startRow":"","endRow":""} []	311,3
+
 ```
 
  ```


### PR DESCRIPTION
Combiner:
- $ bin/accumulo shell -u username" updated to "$ accumulo shell -u root"
- added "username@instance examples.runners> config -t examples.runners -s table.class.loader.context=file:///path/to/accumulo-examples/target/accumulo-examples.jar" before setiter command

Delete Key Value Pair
- "$ /path/to/accumulo shell -u username -p secret" up updated to "$ accumulo shell --user root --password secret" in 3 locations
- "$ /path/to/accumulo rfile-info -d hdfs://localhost/accumulo/tables/1t/default_tablet/F00007em.rf" updated to "$ accumulo file rfile-info -d hdfs://localhost/accumulo/tables/1t/default_tablet/F00007em.rf" in 3 locations
