### PR TITLE
Update impsort-maven-plugin to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
       <plugin>
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <configuration>
           <removeUnused>true</removeUnused>
           <groups>java.,javax.,jakarta.,org.,com.</groups>


### PR DESCRIPTION
Executing a build with version 1.7.0 of the impsort-maven-plugin fails due to a missing required class when attempting to execute the sort goal of the plugin: org/codehaus/plexus/util/DirectoryScanner

Using version 1.8.0 of the plugin allows the build to succeed.

This resolves the building issues